### PR TITLE
Manually modified empty reference cases for now & modified `addRef.xq` for future cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ $RECYCLE.BIN/
 node_modules/
 
 *.code-workspace
+src/three_times_to_jiangnan/xquery/debugging.xquery

--- a/src/three_times_to_jiangnan/wit_c/xml/余飞三下南京.xml
+++ b/src/three_times_to_jiangnan/wit_c/xml/余飞三下南京.xml
@@ -241,10 +241,10 @@
                     <corr>并</corr>
                 </choice>
                 要求见
-                <persName ref="#">谢<roleName>部长</roleName>
+                <persName>谢<roleName>部长</roleName>
                 </persName>
                 。她说明情况，送上信。
-                <persName ref="#">谢<roleName>部长</roleName>
+                <persName>谢<roleName>部长</roleName>
                 </persName>
                 拆开一看，写的是：要破此案，必须派老黄牛来。老黄牛是谁呢？问
                 <orgName ref="#O0010">保密局</orgName>

--- a/src/three_times_to_jiangnan/xquery/addRef.xq
+++ b/src/three_times_to_jiangnan/xquery/addRef.xq
@@ -9,21 +9,27 @@ declare variable $standOff := doc("../standOff.xml");
 declare function local:add-place-ref($input as node()*)
 {
 for $n in $input//*:text//*:placeName
-return update insert  attribute ref{"#"||data($standOff//*:placeName[./string() = $n/string()]/../@*:id)} into $n
+return if($standOff//*:placeName[./string() = $n/string()])
+then update insert  attribute ref{"#"||data($standOff//*:placeName[./string() = $n/string()]/../@*:id)} into $n
+else ()
 };
 
 
 declare function local:add-person-ref($input as node()*)
 {
 for $n in $input//*:text//*:persName
-return update insert  attribute ref{"#"||data($standOff//*:persName[./string() = $n/string()]/../@*:id)} into $n
+return if($standOff//*:persName[./string() = $n/string()])
+then update insert  attribute ref{"#"||data($standOff//*:persName[./string() = $n/string()]/../@*:id)} into $n
+else ()
 };
 
 
 declare function local:add-org-ref($input as node()*)
 {
 for $n in $input//*:text//*:orgName
-return update insert  attribute ref{"#"||data($standOff//*:orgName[./string() = $n/string()]/../@*:id)} into $n
+return if($standOff//*:orgName[./string() = $n/string()])
+then update insert  attribute ref{"#"||data($standOff//*:orgName[./string() = $n/string()]/../@*:id)} into $n
+else ()
 };
 
 local:add-place-ref($sanjin-A|$sanjin-B|$sanjin-C),


### PR DESCRIPTION
close #50 
- Manually modified the empty reference cases. (If necessary, could be done with an XQuery script in the future.)

- Modified `addRef.xq`: Use predicate to filter the case that entity name does not exist in `standOff.xml`  (which might happen due to a manual modification of the `standOff.xml`
