### PR TITLE
CSS transform error with extended version of Hugo

### DIFF
--- a/public/en/index.html
+++ b/public/en/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-us">
+<html lang="de">
   <head>
     <title>https://readchina.github.io/shouchaoben/</title>
     <link rel="canonical" href="https://readchina.github.io/shouchaoben/">

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,12 +2,12 @@
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   
   <sitemap>
-    <loc>https://readchina.github.io/shouchaoben/en/sitemap.xml</loc>
+    <loc>https://readchina.github.io/shouchaoben/de/sitemap.xml</loc>
     
   </sitemap>
   
   <sitemap>
-    <loc>https://readchina.github.io/shouchaoben/de/sitemap.xml</loc>
+    <loc>https://readchina.github.io/shouchaoben/en/sitemap.xml</loc>
     
   </sitemap>
   

--- a/resources/_gen/assets/sass/sass/style.sass_4d6f00452a35742ddbb489cb3703195e.content
+++ b/resources/_gen/assets/sass/sass/style.sass_4d6f00452a35742ddbb489cb3703195e.content
@@ -1,0 +1,12544 @@
+/* vietnamese */
+@font-face {
+  font-family: "Nunito Sans";
+  font-style: normal;
+  font-weight: normal;
+  src: local("Nunito Sans Regular"), local("NunitoSans-Regular"), url(../fonts/NunitoSans/NunitoSans-Regular.ttf) format("woff2");
+  unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB; }
+
+/* latin-ext */
+@font-face {
+  font-family: "Nunito Sans";
+  font-style: normal;
+  font-weight: normal;
+  src: local("Nunito Sans Regular"), local("NunitoSans-Regular"), url(../fonts/NunitoSans/NunitoSans-Regular.ttf) format("woff2");
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+/* latin */
+@font-face {
+  font-family: "Nunito Sans";
+  font-style: normal;
+  font-weight: normal;
+  src: local("Nunito Sans Regular"), local("NunitoSans-Regular"), url(../fonts/NunitoSans/NunitoSans-Regular.ttf) format("woff2");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
+
+.is-unselectable {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none; }
+
+.navbar-link:not(.is-arrowless)::after {
+  border: 3px solid transparent;
+  border-radius: 2px;
+  border-right: 0;
+  border-top: 0;
+  content: " ";
+  display: block;
+  height: 0.625em;
+  margin-top: -0.4375em;
+  pointer-events: none;
+  position: absolute;
+  top: 50%;
+  transform: rotate(-45deg);
+  transform-origin: center;
+  width: 0.625em; }
+
+.title:not(:last-child),
+.subtitle:not(:last-child) {
+  margin-bottom: 1.5rem; }
+
+.modal-close {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  background-color: rgba(10, 10, 10, 0.2);
+  border: none;
+  border-radius: 290486px;
+  cursor: pointer;
+  pointer-events: auto;
+  display: inline-block;
+  flex-grow: 0;
+  flex-shrink: 0;
+  font-size: 0;
+  height: 20px;
+  max-height: 20px;
+  max-width: 20px;
+  min-height: 20px;
+  min-width: 20px;
+  outline: none;
+  position: relative;
+  vertical-align: top;
+  width: 20px; }
+  .modal-close::before, .modal-close::after {
+    background-color: white;
+    content: "";
+    display: block;
+    left: 50%;
+    position: absolute;
+    top: 50%;
+    transform: translateX(-50%) translateY(-50%) rotate(45deg);
+    transform-origin: center center; }
+  .modal-close::before {
+    height: 2px;
+    width: 50%; }
+  .modal-close::after {
+    height: 50%;
+    width: 2px; }
+  .modal-close:hover, .modal-close:focus {
+    background-color: rgba(10, 10, 10, 0.3); }
+  .modal-close:active {
+    background-color: rgba(10, 10, 10, 0.4); }
+  .is-small.modal-close {
+    height: 16px;
+    max-height: 16px;
+    max-width: 16px;
+    min-height: 16px;
+    min-width: 16px;
+    width: 16px; }
+  .is-medium.modal-close {
+    height: 24px;
+    max-height: 24px;
+    max-width: 24px;
+    min-height: 24px;
+    min-width: 24px;
+    width: 24px; }
+  .is-large.modal-close {
+    height: 32px;
+    max-height: 32px;
+    max-width: 32px;
+    min-height: 32px;
+    min-width: 32px;
+    width: 32px; }
+
+.hero-video, .modal-background, .modal, .image.is-square img,
+.image.is-square .has-ratio, .image.is-1by1 img,
+.image.is-1by1 .has-ratio, .image.is-5by4 img,
+.image.is-5by4 .has-ratio, .image.is-4by3 img,
+.image.is-4by3 .has-ratio, .image.is-3by2 img,
+.image.is-3by2 .has-ratio, .image.is-5by3 img,
+.image.is-5by3 .has-ratio, .image.is-16by9 img,
+.image.is-16by9 .has-ratio, .image.is-2by1 img,
+.image.is-2by1 .has-ratio, .image.is-3by1 img,
+.image.is-3by1 .has-ratio, .image.is-4by5 img,
+.image.is-4by5 .has-ratio, .image.is-3by4 img,
+.image.is-3by4 .has-ratio, .image.is-2by3 img,
+.image.is-2by3 .has-ratio, .image.is-3by5 img,
+.image.is-3by5 .has-ratio, .image.is-9by16 img,
+.image.is-9by16 .has-ratio, .image.is-1by2 img,
+.image.is-1by2 .has-ratio, .image.is-1by3 img,
+.image.is-1by3 .has-ratio, .is-overlay {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0; }
+
+/*! minireset.css v0.0.6 | MIT License | github.com/jgthms/minireset.css */
+html,
+body,
+p,
+ol,
+ul,
+li,
+dl,
+dt,
+dd,
+blockquote,
+figure,
+fieldset,
+legend,
+textarea,
+pre,
+iframe,
+hr,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+  padding: 0; }
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: 100%;
+  font-weight: normal; }
+
+ul {
+  list-style: none; }
+
+button,
+input,
+select,
+textarea {
+  margin: 0; }
+
+html {
+  box-sizing: border-box; }
+
+*, *::before, *::after {
+  box-sizing: inherit; }
+
+img,
+video {
+  height: auto;
+  max-width: 100%; }
+
+iframe {
+  border: 0; }
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0; }
+
+td,
+th {
+  padding: 0; }
+  td:not([align]),
+  th:not([align]) {
+    text-align: inherit; }
+
+html {
+  background-color: white;
+  font-size: 16px;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  min-width: 300px;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  text-rendering: optimizeLegibility;
+  text-size-adjust: 100%; }
+
+article,
+aside,
+figure,
+footer,
+header,
+hgroup,
+section {
+  display: block; }
+
+body,
+button,
+input,
+select,
+textarea {
+  font-family: Nunito Sans, sans-serif; }
+
+code,
+pre {
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: auto;
+  font-family: monospace; }
+
+body {
+  color: #4a4a4a;
+  font-size: 1em;
+  font-weight: 400;
+  line-height: 1.5; }
+
+a {
+  color: #3273dc;
+  cursor: pointer;
+  text-decoration: none; }
+  a strong {
+    color: currentColor; }
+  a:hover {
+    color: #000000; }
+
+code {
+  background-color: transparent;
+  color: #00b8d4;
+  font-size: 0.875em;
+  font-weight: normal;
+  padding: 0.25em 0.5em 0.25em; }
+
+hr {
+  background-color: #ffffff;
+  border: none;
+  display: block;
+  height: 2px;
+  margin: 1.5rem 0; }
+
+img {
+  height: auto;
+  max-width: 100%; }
+
+input[type="checkbox"],
+input[type="radio"] {
+  vertical-align: baseline; }
+
+small {
+  font-size: 0.875em; }
+
+span {
+  font-style: inherit;
+  font-weight: inherit; }
+
+strong {
+  color: #363636;
+  font-weight: 700; }
+
+fieldset {
+  border: none; }
+
+pre {
+  -webkit-overflow-scrolling: touch;
+  background-color: #ffffff;
+  color: #4a4a4a;
+  font-size: 0.875em;
+  overflow-x: auto;
+  padding: 1.25rem 1.5rem;
+  white-space: pre;
+  word-wrap: normal; }
+  pre code {
+    background-color: transparent;
+    color: currentColor;
+    font-size: 1em;
+    padding: 0; }
+
+table td,
+table th {
+  vertical-align: top; }
+  table td:not([align]),
+  table th:not([align]) {
+    text-align: inherit; }
+
+table th {
+  color: #363636; }
+
+.has-text-white {
+  color: white !important; }
+
+a.has-text-white:hover, a.has-text-white:focus {
+  color: #e6e6e6 !important; }
+
+.has-background-white {
+  background-color: white !important; }
+
+.has-text-black {
+  color: #0a0a0a !important; }
+
+a.has-text-black:hover, a.has-text-black:focus {
+  color: black !important; }
+
+.has-background-black {
+  background-color: #0a0a0a !important; }
+
+.has-text-light {
+  color: whitesmoke !important; }
+
+a.has-text-light:hover, a.has-text-light:focus {
+  color: #dbdbdb !important; }
+
+.has-background-light {
+  background-color: whitesmoke !important; }
+
+.has-text-dark {
+  color: #363636 !important; }
+
+a.has-text-dark:hover, a.has-text-dark:focus {
+  color: #1c1c1c !important; }
+
+.has-background-dark {
+  background-color: #363636 !important; }
+
+.has-text-primary {
+  color: #00b8d4 !important; }
+
+a.has-text-primary:hover, a.has-text-primary:focus {
+  color: #008ca1 !important; }
+
+.has-background-primary {
+  background-color: #00b8d4 !important; }
+
+.has-text-primary-light {
+  color: #ebfcff !important; }
+
+a.has-text-primary-light:hover, a.has-text-primary-light:focus {
+  color: #b8f6ff !important; }
+
+.has-background-primary-light {
+  background-color: #ebfcff !important; }
+
+.has-text-primary-dark {
+  color: #0096ad !important; }
+
+a.has-text-primary-dark:hover, a.has-text-primary-dark:focus {
+  color: #00c3e0 !important; }
+
+.has-background-primary-dark {
+  background-color: #0096ad !important; }
+
+.has-text-link {
+  color: #3273dc !important; }
+
+a.has-text-link:hover, a.has-text-link:focus {
+  color: #205bbc !important; }
+
+.has-background-link {
+  background-color: #3273dc !important; }
+
+.has-text-link-light {
+  color: #eef3fc !important; }
+
+a.has-text-link-light:hover, a.has-text-link-light:focus {
+  color: #c2d5f5 !important; }
+
+.has-background-link-light {
+  background-color: #eef3fc !important; }
+
+.has-text-link-dark {
+  color: #2160c4 !important; }
+
+a.has-text-link-dark:hover, a.has-text-link-dark:focus {
+  color: #3b79de !important; }
+
+.has-background-link-dark {
+  background-color: #2160c4 !important; }
+
+.has-text-info {
+  color: #3298dc !important; }
+
+a.has-text-info:hover, a.has-text-info:focus {
+  color: #207dbc !important; }
+
+.has-background-info {
+  background-color: #3298dc !important; }
+
+.has-text-info-light {
+  color: #eef6fc !important; }
+
+a.has-text-info-light:hover, a.has-text-info-light:focus {
+  color: #c2e0f5 !important; }
+
+.has-background-info-light {
+  background-color: #eef6fc !important; }
+
+.has-text-info-dark {
+  color: #1d72aa !important; }
+
+a.has-text-info-dark:hover, a.has-text-info-dark:focus {
+  color: #248fd6 !important; }
+
+.has-background-info-dark {
+  background-color: #1d72aa !important; }
+
+.has-text-success {
+  color: #48c774 !important; }
+
+a.has-text-success:hover, a.has-text-success:focus {
+  color: #34a85c !important; }
+
+.has-background-success {
+  background-color: #48c774 !important; }
+
+.has-text-success-light {
+  color: #effaf3 !important; }
+
+a.has-text-success-light:hover, a.has-text-success-light:focus {
+  color: #c8eed6 !important; }
+
+.has-background-success-light {
+  background-color: #effaf3 !important; }
+
+.has-text-success-dark {
+  color: #257942 !important; }
+
+a.has-text-success-dark:hover, a.has-text-success-dark:focus {
+  color: #31a058 !important; }
+
+.has-background-success-dark {
+  background-color: #257942 !important; }
+
+.has-text-warning {
+  color: #ffdd57 !important; }
+
+a.has-text-warning:hover, a.has-text-warning:focus {
+  color: #ffd324 !important; }
+
+.has-background-warning {
+  background-color: #ffdd57 !important; }
+
+.has-text-warning-light {
+  color: #fffbeb !important; }
+
+a.has-text-warning-light:hover, a.has-text-warning-light:focus {
+  color: #fff1b8 !important; }
+
+.has-background-warning-light {
+  background-color: #fffbeb !important; }
+
+.has-text-warning-dark {
+  color: #947600 !important; }
+
+a.has-text-warning-dark:hover, a.has-text-warning-dark:focus {
+  color: #c79f00 !important; }
+
+.has-background-warning-dark {
+  background-color: #947600 !important; }
+
+.has-text-danger {
+  color: #f14668 !important; }
+
+a.has-text-danger:hover, a.has-text-danger:focus {
+  color: #ee1742 !important; }
+
+.has-background-danger {
+  background-color: #f14668 !important; }
+
+.has-text-danger-light {
+  color: #feecf0 !important; }
+
+a.has-text-danger-light:hover, a.has-text-danger-light:focus {
+  color: #fabdc9 !important; }
+
+.has-background-danger-light {
+  background-color: #feecf0 !important; }
+
+.has-text-danger-dark {
+  color: #cc0f35 !important; }
+
+a.has-text-danger-dark:hover, a.has-text-danger-dark:focus {
+  color: #ee2049 !important; }
+
+.has-background-danger-dark {
+  background-color: #cc0f35 !important; }
+
+.has-text-black-bis {
+  color: #121212 !important; }
+
+.has-background-black-bis {
+  background-color: #121212 !important; }
+
+.has-text-black-ter {
+  color: #242424 !important; }
+
+.has-background-black-ter {
+  background-color: #242424 !important; }
+
+.has-text-grey-darker {
+  color: #363636 !important; }
+
+.has-background-grey-darker {
+  background-color: #363636 !important; }
+
+.has-text-grey-dark {
+  color: #4a4a4a !important; }
+
+.has-background-grey-dark {
+  background-color: #4a4a4a !important; }
+
+.has-text-grey {
+  color: #7a7a7a !important; }
+
+.has-background-grey {
+  background-color: #7a7a7a !important; }
+
+.has-text-grey-light {
+  color: #b5b5b5 !important; }
+
+.has-background-grey-light {
+  background-color: #b5b5b5 !important; }
+
+.has-text-grey-lighter {
+  color: #dbdbdb !important; }
+
+.has-background-grey-lighter {
+  background-color: #dbdbdb !important; }
+
+.has-text-white-ter {
+  color: whitesmoke !important; }
+
+.has-background-white-ter {
+  background-color: whitesmoke !important; }
+
+.has-text-white-bis {
+  color: #fafafa !important; }
+
+.has-background-white-bis {
+  background-color: #fafafa !important; }
+
+.is-clearfix::after {
+  clear: both;
+  content: " ";
+  display: table; }
+
+.is-pulled-left {
+  float: left !important; }
+
+.is-pulled-right {
+  float: right !important; }
+
+.is-radiusless {
+  border-radius: 0 !important; }
+
+.is-shadowless {
+  box-shadow: none !important; }
+
+.is-clipped {
+  overflow: hidden !important; }
+
+.is-relative {
+  position: relative !important; }
+
+.is-marginless {
+  margin: 0 !important; }
+
+.is-paddingless {
+  padding: 0 !important; }
+
+.mt-0 {
+  margin-top: 0 !important; }
+
+.mr-0 {
+  margin-right: 0 !important; }
+
+.mb-0 {
+  margin-bottom: 0 !important; }
+
+.ml-0 {
+  margin-left: 0 !important; }
+
+.mx-0 {
+  margin-left: 0 !important;
+  margin-right: 0 !important; }
+
+.my-0 {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important; }
+
+.mt-1 {
+  margin-top: 0.25rem !important; }
+
+.mr-1 {
+  margin-right: 0.25rem !important; }
+
+.mb-1 {
+  margin-bottom: 0.25rem !important; }
+
+.ml-1 {
+  margin-left: 0.25rem !important; }
+
+.mx-1 {
+  margin-left: 0.25rem !important;
+  margin-right: 0.25rem !important; }
+
+.my-1 {
+  margin-top: 0.25rem !important;
+  margin-bottom: 0.25rem !important; }
+
+.mt-2 {
+  margin-top: 0.5rem !important; }
+
+.mr-2 {
+  margin-right: 0.5rem !important; }
+
+.mb-2 {
+  margin-bottom: 0.5rem !important; }
+
+.ml-2 {
+  margin-left: 0.5rem !important; }
+
+.mx-2 {
+  margin-left: 0.5rem !important;
+  margin-right: 0.5rem !important; }
+
+.my-2 {
+  margin-top: 0.5rem !important;
+  margin-bottom: 0.5rem !important; }
+
+.mt-3 {
+  margin-top: 0.75rem !important; }
+
+.mr-3 {
+  margin-right: 0.75rem !important; }
+
+.mb-3 {
+  margin-bottom: 0.75rem !important; }
+
+.ml-3 {
+  margin-left: 0.75rem !important; }
+
+.mx-3 {
+  margin-left: 0.75rem !important;
+  margin-right: 0.75rem !important; }
+
+.my-3 {
+  margin-top: 0.75rem !important;
+  margin-bottom: 0.75rem !important; }
+
+.mt-4 {
+  margin-top: 1rem !important; }
+
+.mr-4 {
+  margin-right: 1rem !important; }
+
+.mb-4 {
+  margin-bottom: 1rem !important; }
+
+.ml-4 {
+  margin-left: 1rem !important; }
+
+.mx-4 {
+  margin-left: 1rem !important;
+  margin-right: 1rem !important; }
+
+.my-4 {
+  margin-top: 1rem !important;
+  margin-bottom: 1rem !important; }
+
+.mt-5 {
+  margin-top: 1.5rem !important; }
+
+.mr-5 {
+  margin-right: 1.5rem !important; }
+
+.mb-5 {
+  margin-bottom: 1.5rem !important; }
+
+.ml-5 {
+  margin-left: 1.5rem !important; }
+
+.mx-5 {
+  margin-left: 1.5rem !important;
+  margin-right: 1.5rem !important; }
+
+.my-5 {
+  margin-top: 1.5rem !important;
+  margin-bottom: 1.5rem !important; }
+
+.mt-6 {
+  margin-top: 3rem !important; }
+
+.mr-6 {
+  margin-right: 3rem !important; }
+
+.mb-6 {
+  margin-bottom: 3rem !important; }
+
+.ml-6 {
+  margin-left: 3rem !important; }
+
+.mx-6 {
+  margin-left: 3rem !important;
+  margin-right: 3rem !important; }
+
+.my-6 {
+  margin-top: 3rem !important;
+  margin-bottom: 3rem !important; }
+
+.pt-0 {
+  padding-top: 0 !important; }
+
+.pr-0 {
+  padding-right: 0 !important; }
+
+.pb-0 {
+  padding-bottom: 0 !important; }
+
+.pl-0 {
+  padding-left: 0 !important; }
+
+.px-0 {
+  padding-left: 0 !important;
+  padding-right: 0 !important; }
+
+.py-0 {
+  padding-top: 0 !important;
+  padding-bottom: 0 !important; }
+
+.pt-1 {
+  padding-top: 0.25rem !important; }
+
+.pr-1 {
+  padding-right: 0.25rem !important; }
+
+.pb-1 {
+  padding-bottom: 0.25rem !important; }
+
+.pl-1 {
+  padding-left: 0.25rem !important; }
+
+.px-1 {
+  padding-left: 0.25rem !important;
+  padding-right: 0.25rem !important; }
+
+.py-1 {
+  padding-top: 0.25rem !important;
+  padding-bottom: 0.25rem !important; }
+
+.pt-2 {
+  padding-top: 0.5rem !important; }
+
+.pr-2 {
+  padding-right: 0.5rem !important; }
+
+.pb-2 {
+  padding-bottom: 0.5rem !important; }
+
+.pl-2 {
+  padding-left: 0.5rem !important; }
+
+.px-2 {
+  padding-left: 0.5rem !important;
+  padding-right: 0.5rem !important; }
+
+.py-2 {
+  padding-top: 0.5rem !important;
+  padding-bottom: 0.5rem !important; }
+
+.pt-3 {
+  padding-top: 0.75rem !important; }
+
+.pr-3 {
+  padding-right: 0.75rem !important; }
+
+.pb-3 {
+  padding-bottom: 0.75rem !important; }
+
+.pl-3 {
+  padding-left: 0.75rem !important; }
+
+.px-3 {
+  padding-left: 0.75rem !important;
+  padding-right: 0.75rem !important; }
+
+.py-3 {
+  padding-top: 0.75rem !important;
+  padding-bottom: 0.75rem !important; }
+
+.pt-4 {
+  padding-top: 1rem !important; }
+
+.pr-4 {
+  padding-right: 1rem !important; }
+
+.pb-4 {
+  padding-bottom: 1rem !important; }
+
+.pl-4 {
+  padding-left: 1rem !important; }
+
+.px-4 {
+  padding-left: 1rem !important;
+  padding-right: 1rem !important; }
+
+.py-4 {
+  padding-top: 1rem !important;
+  padding-bottom: 1rem !important; }
+
+.pt-5 {
+  padding-top: 1.5rem !important; }
+
+.pr-5 {
+  padding-right: 1.5rem !important; }
+
+.pb-5 {
+  padding-bottom: 1.5rem !important; }
+
+.pl-5 {
+  padding-left: 1.5rem !important; }
+
+.px-5 {
+  padding-left: 1.5rem !important;
+  padding-right: 1.5rem !important; }
+
+.py-5 {
+  padding-top: 1.5rem !important;
+  padding-bottom: 1.5rem !important; }
+
+.pt-6 {
+  padding-top: 3rem !important; }
+
+.pr-6 {
+  padding-right: 3rem !important; }
+
+.pb-6 {
+  padding-bottom: 3rem !important; }
+
+.pl-6 {
+  padding-left: 3rem !important; }
+
+.px-6 {
+  padding-left: 3rem !important;
+  padding-right: 3rem !important; }
+
+.py-6 {
+  padding-top: 3rem !important;
+  padding-bottom: 3rem !important; }
+
+.is-size-1 {
+  font-size: 3rem !important; }
+
+.is-size-2 {
+  font-size: 2.5rem !important; }
+
+.is-size-3 {
+  font-size: 2rem !important; }
+
+.is-size-4 {
+  font-size: 1.5rem !important; }
+
+.is-size-5 {
+  font-size: 1.25rem !important; }
+
+.is-size-6 {
+  font-size: 1rem !important; }
+
+.is-size-7 {
+  font-size: 0.75rem !important; }
+
+@media screen and (max-width: 768px) {
+  .is-size-1-mobile {
+    font-size: 3rem !important; }
+  .is-size-2-mobile {
+    font-size: 2.5rem !important; }
+  .is-size-3-mobile {
+    font-size: 2rem !important; }
+  .is-size-4-mobile {
+    font-size: 1.5rem !important; }
+  .is-size-5-mobile {
+    font-size: 1.25rem !important; }
+  .is-size-6-mobile {
+    font-size: 1rem !important; }
+  .is-size-7-mobile {
+    font-size: 0.75rem !important; } }
+
+@media screen and (min-width: 769px), print {
+  .is-size-1-tablet {
+    font-size: 3rem !important; }
+  .is-size-2-tablet {
+    font-size: 2.5rem !important; }
+  .is-size-3-tablet {
+    font-size: 2rem !important; }
+  .is-size-4-tablet {
+    font-size: 1.5rem !important; }
+  .is-size-5-tablet {
+    font-size: 1.25rem !important; }
+  .is-size-6-tablet {
+    font-size: 1rem !important; }
+  .is-size-7-tablet {
+    font-size: 0.75rem !important; } }
+
+@media screen and (max-width: 1023px) {
+  .is-size-1-touch {
+    font-size: 3rem !important; }
+  .is-size-2-touch {
+    font-size: 2.5rem !important; }
+  .is-size-3-touch {
+    font-size: 2rem !important; }
+  .is-size-4-touch {
+    font-size: 1.5rem !important; }
+  .is-size-5-touch {
+    font-size: 1.25rem !important; }
+  .is-size-6-touch {
+    font-size: 1rem !important; }
+  .is-size-7-touch {
+    font-size: 0.75rem !important; } }
+
+@media screen and (min-width: 1024px) {
+  .is-size-1-desktop {
+    font-size: 3rem !important; }
+  .is-size-2-desktop {
+    font-size: 2.5rem !important; }
+  .is-size-3-desktop {
+    font-size: 2rem !important; }
+  .is-size-4-desktop {
+    font-size: 1.5rem !important; }
+  .is-size-5-desktop {
+    font-size: 1.25rem !important; }
+  .is-size-6-desktop {
+    font-size: 1rem !important; }
+  .is-size-7-desktop {
+    font-size: 0.75rem !important; } }
+
+@media screen and (min-width: 1216px) {
+  .is-size-1-widescreen {
+    font-size: 3rem !important; }
+  .is-size-2-widescreen {
+    font-size: 2.5rem !important; }
+  .is-size-3-widescreen {
+    font-size: 2rem !important; }
+  .is-size-4-widescreen {
+    font-size: 1.5rem !important; }
+  .is-size-5-widescreen {
+    font-size: 1.25rem !important; }
+  .is-size-6-widescreen {
+    font-size: 1rem !important; }
+  .is-size-7-widescreen {
+    font-size: 0.75rem !important; } }
+
+@media screen and (min-width: 1408px) {
+  .is-size-1-fullhd {
+    font-size: 3rem !important; }
+  .is-size-2-fullhd {
+    font-size: 2.5rem !important; }
+  .is-size-3-fullhd {
+    font-size: 2rem !important; }
+  .is-size-4-fullhd {
+    font-size: 1.5rem !important; }
+  .is-size-5-fullhd {
+    font-size: 1.25rem !important; }
+  .is-size-6-fullhd {
+    font-size: 1rem !important; }
+  .is-size-7-fullhd {
+    font-size: 0.75rem !important; } }
+
+.has-text-centered {
+  text-align: center !important; }
+
+.has-text-justified {
+  text-align: justify !important; }
+
+.has-text-left {
+  text-align: left !important; }
+
+.has-text-right {
+  text-align: right !important; }
+
+@media screen and (max-width: 768px) {
+  .has-text-centered-mobile {
+    text-align: center !important; } }
+
+@media screen and (min-width: 769px), print {
+  .has-text-centered-tablet {
+    text-align: center !important; } }
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .has-text-centered-tablet-only {
+    text-align: center !important; } }
+
+@media screen and (max-width: 1023px) {
+  .has-text-centered-touch {
+    text-align: center !important; } }
+
+@media screen and (min-width: 1024px) {
+  .has-text-centered-desktop {
+    text-align: center !important; } }
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .has-text-centered-desktop-only {
+    text-align: center !important; } }
+
+@media screen and (min-width: 1216px) {
+  .has-text-centered-widescreen {
+    text-align: center !important; } }
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .has-text-centered-widescreen-only {
+    text-align: center !important; } }
+
+@media screen and (min-width: 1408px) {
+  .has-text-centered-fullhd {
+    text-align: center !important; } }
+
+@media screen and (max-width: 768px) {
+  .has-text-justified-mobile {
+    text-align: justify !important; } }
+
+@media screen and (min-width: 769px), print {
+  .has-text-justified-tablet {
+    text-align: justify !important; } }
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .has-text-justified-tablet-only {
+    text-align: justify !important; } }
+
+@media screen and (max-width: 1023px) {
+  .has-text-justified-touch {
+    text-align: justify !important; } }
+
+@media screen and (min-width: 1024px) {
+  .has-text-justified-desktop {
+    text-align: justify !important; } }
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .has-text-justified-desktop-only {
+    text-align: justify !important; } }
+
+@media screen and (min-width: 1216px) {
+  .has-text-justified-widescreen {
+    text-align: justify !important; } }
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .has-text-justified-widescreen-only {
+    text-align: justify !important; } }
+
+@media screen and (min-width: 1408px) {
+  .has-text-justified-fullhd {
+    text-align: justify !important; } }
+
+@media screen and (max-width: 768px) {
+  .has-text-left-mobile {
+    text-align: left !important; } }
+
+@media screen and (min-width: 769px), print {
+  .has-text-left-tablet {
+    text-align: left !important; } }
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .has-text-left-tablet-only {
+    text-align: left !important; } }
+
+@media screen and (max-width: 1023px) {
+  .has-text-left-touch {
+    text-align: left !important; } }
+
+@media screen and (min-width: 1024px) {
+  .has-text-left-desktop {
+    text-align: left !important; } }
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .has-text-left-desktop-only {
+    text-align: left !important; } }
+
+@media screen and (min-width: 1216px) {
+  .has-text-left-widescreen {
+    text-align: left !important; } }
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .has-text-left-widescreen-only {
+    text-align: left !important; } }
+
+@media screen and (min-width: 1408px) {
+  .has-text-left-fullhd {
+    text-align: left !important; } }
+
+@media screen and (max-width: 768px) {
+  .has-text-right-mobile {
+    text-align: right !important; } }
+
+@media screen and (min-width: 769px), print {
+  .has-text-right-tablet {
+    text-align: right !important; } }
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .has-text-right-tablet-only {
+    text-align: right !important; } }
+
+@media screen and (max-width: 1023px) {
+  .has-text-right-touch {
+    text-align: right !important; } }
+
+@media screen and (min-width: 1024px) {
+  .has-text-right-desktop {
+    text-align: right !important; } }
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .has-text-right-desktop-only {
+    text-align: right !important; } }
+
+@media screen and (min-width: 1216px) {
+  .has-text-right-widescreen {
+    text-align: right !important; } }
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .has-text-right-widescreen-only {
+    text-align: right !important; } }
+
+@media screen and (min-width: 1408px) {
+  .has-text-right-fullhd {
+    text-align: right !important; } }
+
+.is-capitalized {
+  text-transform: capitalize !important; }
+
+.is-lowercase {
+  text-transform: lowercase !important; }
+
+.is-uppercase {
+  text-transform: uppercase !important; }
+
+.is-italic {
+  font-style: italic !important; }
+
+.has-text-weight-light {
+  font-weight: 300 !important; }
+
+.has-text-weight-normal {
+  font-weight: 400 !important; }
+
+.has-text-weight-medium {
+  font-weight: 500 !important; }
+
+.has-text-weight-semibold {
+  font-weight: 600 !important; }
+
+.has-text-weight-bold {
+  font-weight: 700 !important; }
+
+.is-family-primary {
+  font-family: Nunito Sans, sans-serif !important; }
+
+.is-family-secondary {
+  font-family: Nunito Sans, sans-serif !important; }
+
+.is-family-sans-serif {
+  font-family: Nunito Sans, sans-serif !important; }
+
+.is-family-monospace {
+  font-family: monospace !important; }
+
+.is-family-code {
+  font-family: monospace !important; }
+
+.is-block {
+  display: block !important; }
+
+@media screen and (max-width: 768px) {
+  .is-block-mobile {
+    display: block !important; } }
+
+@media screen and (min-width: 769px), print {
+  .is-block-tablet {
+    display: block !important; } }
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-block-tablet-only {
+    display: block !important; } }
+
+@media screen and (max-width: 1023px) {
+  .is-block-touch {
+    display: block !important; } }
+
+@media screen and (min-width: 1024px) {
+  .is-block-desktop {
+    display: block !important; } }
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-block-desktop-only {
+    display: block !important; } }
+
+@media screen and (min-width: 1216px) {
+  .is-block-widescreen {
+    display: block !important; } }
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-block-widescreen-only {
+    display: block !important; } }
+
+@media screen and (min-width: 1408px) {
+  .is-block-fullhd {
+    display: block !important; } }
+
+.is-flex {
+  display: flex !important; }
+
+@media screen and (max-width: 768px) {
+  .is-flex-mobile {
+    display: flex !important; } }
+
+@media screen and (min-width: 769px), print {
+  .is-flex-tablet {
+    display: flex !important; } }
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-flex-tablet-only {
+    display: flex !important; } }
+
+@media screen and (max-width: 1023px) {
+  .is-flex-touch {
+    display: flex !important; } }
+
+@media screen and (min-width: 1024px) {
+  .is-flex-desktop {
+    display: flex !important; } }
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-flex-desktop-only {
+    display: flex !important; } }
+
+@media screen and (min-width: 1216px) {
+  .is-flex-widescreen {
+    display: flex !important; } }
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-flex-widescreen-only {
+    display: flex !important; } }
+
+@media screen and (min-width: 1408px) {
+  .is-flex-fullhd {
+    display: flex !important; } }
+
+.is-inline {
+  display: inline !important; }
+
+@media screen and (max-width: 768px) {
+  .is-inline-mobile {
+    display: inline !important; } }
+
+@media screen and (min-width: 769px), print {
+  .is-inline-tablet {
+    display: inline !important; } }
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-inline-tablet-only {
+    display: inline !important; } }
+
+@media screen and (max-width: 1023px) {
+  .is-inline-touch {
+    display: inline !important; } }
+
+@media screen and (min-width: 1024px) {
+  .is-inline-desktop {
+    display: inline !important; } }
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-inline-desktop-only {
+    display: inline !important; } }
+
+@media screen and (min-width: 1216px) {
+  .is-inline-widescreen {
+    display: inline !important; } }
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-inline-widescreen-only {
+    display: inline !important; } }
+
+@media screen and (min-width: 1408px) {
+  .is-inline-fullhd {
+    display: inline !important; } }
+
+.is-inline-block {
+  display: inline-block !important; }
+
+@media screen and (max-width: 768px) {
+  .is-inline-block-mobile {
+    display: inline-block !important; } }
+
+@media screen and (min-width: 769px), print {
+  .is-inline-block-tablet {
+    display: inline-block !important; } }
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-inline-block-tablet-only {
+    display: inline-block !important; } }
+
+@media screen and (max-width: 1023px) {
+  .is-inline-block-touch {
+    display: inline-block !important; } }
+
+@media screen and (min-width: 1024px) {
+  .is-inline-block-desktop {
+    display: inline-block !important; } }
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-inline-block-desktop-only {
+    display: inline-block !important; } }
+
+@media screen and (min-width: 1216px) {
+  .is-inline-block-widescreen {
+    display: inline-block !important; } }
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-inline-block-widescreen-only {
+    display: inline-block !important; } }
+
+@media screen and (min-width: 1408px) {
+  .is-inline-block-fullhd {
+    display: inline-block !important; } }
+
+.is-inline-flex {
+  display: inline-flex !important; }
+
+@media screen and (max-width: 768px) {
+  .is-inline-flex-mobile {
+    display: inline-flex !important; } }
+
+@media screen and (min-width: 769px), print {
+  .is-inline-flex-tablet {
+    display: inline-flex !important; } }
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-inline-flex-tablet-only {
+    display: inline-flex !important; } }
+
+@media screen and (max-width: 1023px) {
+  .is-inline-flex-touch {
+    display: inline-flex !important; } }
+
+@media screen and (min-width: 1024px) {
+  .is-inline-flex-desktop {
+    display: inline-flex !important; } }
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-inline-flex-desktop-only {
+    display: inline-flex !important; } }
+
+@media screen and (min-width: 1216px) {
+  .is-inline-flex-widescreen {
+    display: inline-flex !important; } }
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-inline-flex-widescreen-only {
+    display: inline-flex !important; } }
+
+@media screen and (min-width: 1408px) {
+  .is-inline-flex-fullhd {
+    display: inline-flex !important; } }
+
+.is-hidden {
+  display: none !important; }
+
+.is-sr-only {
+  border: none !important;
+  clip: rect(0, 0, 0, 0) !important;
+  height: 0.01em !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  position: absolute !important;
+  white-space: nowrap !important;
+  width: 0.01em !important; }
+
+@media screen and (max-width: 768px) {
+  .is-hidden-mobile {
+    display: none !important; } }
+
+@media screen and (min-width: 769px), print {
+  .is-hidden-tablet {
+    display: none !important; } }
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-hidden-tablet-only {
+    display: none !important; } }
+
+@media screen and (max-width: 1023px) {
+  .is-hidden-touch {
+    display: none !important; } }
+
+@media screen and (min-width: 1024px) {
+  .is-hidden-desktop {
+    display: none !important; } }
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-hidden-desktop-only {
+    display: none !important; } }
+
+@media screen and (min-width: 1216px) {
+  .is-hidden-widescreen {
+    display: none !important; } }
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-hidden-widescreen-only {
+    display: none !important; } }
+
+@media screen and (min-width: 1408px) {
+  .is-hidden-fullhd {
+    display: none !important; } }
+
+.is-invisible {
+  visibility: hidden !important; }
+
+@media screen and (max-width: 768px) {
+  .is-invisible-mobile {
+    visibility: hidden !important; } }
+
+@media screen and (min-width: 769px), print {
+  .is-invisible-tablet {
+    visibility: hidden !important; } }
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-invisible-tablet-only {
+    visibility: hidden !important; } }
+
+@media screen and (max-width: 1023px) {
+  .is-invisible-touch {
+    visibility: hidden !important; } }
+
+@media screen and (min-width: 1024px) {
+  .is-invisible-desktop {
+    visibility: hidden !important; } }
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-invisible-desktop-only {
+    visibility: hidden !important; } }
+
+@media screen and (min-width: 1216px) {
+  .is-invisible-widescreen {
+    visibility: hidden !important; } }
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-invisible-widescreen-only {
+    visibility: hidden !important; } }
+
+@media screen and (min-width: 1408px) {
+  .is-invisible-fullhd {
+    visibility: hidden !important; } }
+
+.container {
+  flex-grow: 1;
+  margin: 0 auto;
+  position: relative;
+  width: auto; }
+  .container.is-fluid {
+    max-width: none;
+    padding-left: 32px;
+    padding-right: 32px;
+    width: 100%; }
+  @media screen and (min-width: 1024px) {
+    .container {
+      max-width: 960px; } }
+  @media screen and (max-width: 1215px) {
+    .container.is-widescreen {
+      max-width: 1152px; } }
+  @media screen and (max-width: 1407px) {
+    .container.is-fullhd {
+      max-width: 1344px; } }
+  @media screen and (min-width: 1216px) {
+    .container {
+      max-width: 1152px; } }
+  @media screen and (min-width: 1408px) {
+    .container {
+      max-width: 1344px; } }
+.image {
+  display: block;
+  position: relative; }
+  .image img {
+    display: block;
+    height: auto;
+    width: 100%; }
+    .image img.is-rounded {
+      border-radius: 290486px; }
+  .image.is-fullwidth {
+    width: 100%; }
+  .image.is-square img,
+  .image.is-square .has-ratio, .image.is-1by1 img,
+  .image.is-1by1 .has-ratio, .image.is-5by4 img,
+  .image.is-5by4 .has-ratio, .image.is-4by3 img,
+  .image.is-4by3 .has-ratio, .image.is-3by2 img,
+  .image.is-3by2 .has-ratio, .image.is-5by3 img,
+  .image.is-5by3 .has-ratio, .image.is-16by9 img,
+  .image.is-16by9 .has-ratio, .image.is-2by1 img,
+  .image.is-2by1 .has-ratio, .image.is-3by1 img,
+  .image.is-3by1 .has-ratio, .image.is-4by5 img,
+  .image.is-4by5 .has-ratio, .image.is-3by4 img,
+  .image.is-3by4 .has-ratio, .image.is-2by3 img,
+  .image.is-2by3 .has-ratio, .image.is-3by5 img,
+  .image.is-3by5 .has-ratio, .image.is-9by16 img,
+  .image.is-9by16 .has-ratio, .image.is-1by2 img,
+  .image.is-1by2 .has-ratio, .image.is-1by3 img,
+  .image.is-1by3 .has-ratio {
+    height: 100%;
+    width: 100%; }
+  .image.is-square, .image.is-1by1 {
+    padding-top: 100%; }
+  .image.is-5by4 {
+    padding-top: 80%; }
+  .image.is-4by3 {
+    padding-top: 75%; }
+  .image.is-3by2 {
+    padding-top: 66.6666%; }
+  .image.is-5by3 {
+    padding-top: 60%; }
+  .image.is-16by9 {
+    padding-top: 56.25%; }
+  .image.is-2by1 {
+    padding-top: 50%; }
+  .image.is-3by1 {
+    padding-top: 33.3333%; }
+  .image.is-4by5 {
+    padding-top: 125%; }
+  .image.is-3by4 {
+    padding-top: 133.3333%; }
+  .image.is-2by3 {
+    padding-top: 150%; }
+  .image.is-3by5 {
+    padding-top: 166.6666%; }
+  .image.is-9by16 {
+    padding-top: 177.7777%; }
+  .image.is-1by2 {
+    padding-top: 200%; }
+  .image.is-1by3 {
+    padding-top: 300%; }
+  .image.is-16x16 {
+    height: 16px;
+    width: 16px; }
+  .image.is-24x24 {
+    height: 24px;
+    width: 24px; }
+  .image.is-32x32 {
+    height: 32px;
+    width: 32px; }
+  .image.is-48x48 {
+    height: 48px;
+    width: 48px; }
+  .image.is-64x64 {
+    height: 64px;
+    width: 64px; }
+  .image.is-96x96 {
+    height: 96px;
+    width: 96px; }
+  .image.is-128x128 {
+    height: 128px;
+    width: 128px; }
+
+.title,
+.subtitle {
+  word-break: break-word; }
+  .title em,
+  .title span,
+  .subtitle em,
+  .subtitle span {
+    font-weight: inherit; }
+  .title sub,
+  .subtitle sub {
+    font-size: 0.75em; }
+  .title sup,
+  .subtitle sup {
+    font-size: 0.75em; }
+  .title .tag,
+  .subtitle .tag {
+    vertical-align: middle; }
+
+.title {
+  color: #363636;
+  font-size: 2rem;
+  font-weight: 300;
+  line-height: 1.125; }
+  .title strong {
+    color: inherit;
+    font-weight: inherit; }
+  .title + .highlight {
+    margin-top: -0.75rem; }
+  .title:not(.is-spaced) + .subtitle {
+    margin-top: -1.25rem; }
+  .title.is-1 {
+    font-size: 3rem; }
+  .title.is-2 {
+    font-size: 2.5rem; }
+  .title.is-3 {
+    font-size: 2rem; }
+  .title.is-4 {
+    font-size: 1.5rem; }
+  .title.is-5 {
+    font-size: 1.25rem; }
+  .title.is-6 {
+    font-size: 1rem; }
+  .title.is-7 {
+    font-size: 0.75rem; }
+
+.subtitle {
+  color: #4a4a4a;
+  font-size: 1.25rem;
+  font-weight: 400;
+  line-height: 1.25; }
+  .subtitle strong {
+    color: #363636;
+    font-weight: 600; }
+  .subtitle:not(.is-spaced) + .title {
+    margin-top: -1.25rem; }
+  .subtitle.is-1 {
+    font-size: 3rem; }
+  .subtitle.is-2 {
+    font-size: 2.5rem; }
+  .subtitle.is-3 {
+    font-size: 2rem; }
+  .subtitle.is-4 {
+    font-size: 1.5rem; }
+  .subtitle.is-5 {
+    font-size: 1.25rem; }
+  .subtitle.is-6 {
+    font-size: 1rem; }
+  .subtitle.is-7 {
+    font-size: 0.75rem; }
+
+.card {
+  background-color: white;
+  box-shadow: 0 0.5em 1em -0.125em rgba(10, 10, 10, 0.1), 0 0px 0 1px rgba(10, 10, 10, 0.02);
+  color: #4a4a4a;
+  max-width: 100%;
+  position: relative; }
+
+.card-header {
+  background-color: transparent;
+  align-items: stretch;
+  box-shadow: 0 0.125em 0.25em rgba(10, 10, 10, 0.1);
+  display: flex; }
+
+.card-header-title {
+  align-items: center;
+  color: #363636;
+  display: flex;
+  flex-grow: 1;
+  font-weight: 700;
+  padding: 0.75rem 1rem; }
+  .card-header-title.is-centered {
+    justify-content: center; }
+
+.card-header-icon {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  padding: 0.75rem 1rem; }
+
+.card-image {
+  display: block;
+  position: relative; }
+
+.card-content {
+  background-color: transparent;
+  padding: 1.5rem; }
+
+.card-footer {
+  background-color: transparent;
+  border-top: 1px solid #ededed;
+  align-items: stretch;
+  display: flex; }
+
+.card-footer-item {
+  align-items: center;
+  display: flex;
+  flex-basis: 0;
+  flex-grow: 1;
+  flex-shrink: 0;
+  justify-content: center;
+  padding: 0.75rem; }
+  .card-footer-item:not(:last-child) {
+    border-right: 1px solid #ededed; }
+
+.card .media:not(:last-child) {
+  margin-bottom: 1.5rem; }
+
+.modal {
+  align-items: center;
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  overflow: hidden;
+  position: fixed;
+  z-index: 40; }
+  .modal.is-active {
+    display: flex; }
+
+.modal-background {
+  background-color: rgba(10, 10, 10, 0.86); }
+
+.modal-content,
+.modal-card {
+  margin: 0 20px;
+  max-height: calc(100vh - 160px);
+  overflow: auto;
+  position: relative;
+  width: 100%; }
+  @media screen and (min-width: 769px), print {
+    .modal-content,
+    .modal-card {
+      margin: 0 auto;
+      max-height: calc(100vh - 40px);
+      width: 640px; } }
+.modal-close {
+  background: none;
+  height: 40px;
+  position: fixed;
+  right: 20px;
+  top: 20px;
+  width: 40px; }
+
+.modal-card {
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 40px);
+  overflow: hidden;
+  -ms-overflow-y: visible; }
+
+.modal-card-head,
+.modal-card-foot {
+  align-items: center;
+  background-color: #ffffff;
+  display: flex;
+  flex-shrink: 0;
+  justify-content: flex-start;
+  padding: 20px;
+  position: relative; }
+
+.modal-card-head {
+  border-bottom: 1px solid #dbdbdb;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px; }
+
+.modal-card-title {
+  color: #363636;
+  flex-grow: 1;
+  flex-shrink: 0;
+  font-size: 1.5rem;
+  line-height: 1; }
+
+.modal-card-foot {
+  border-bottom-left-radius: 6px;
+  border-bottom-right-radius: 6px;
+  border-top: 1px solid #dbdbdb; }
+  .modal-card-foot .button:not(:last-child) {
+    margin-right: 0.5em; }
+
+.modal-card-body {
+  -webkit-overflow-scrolling: touch;
+  background-color: white;
+  flex-grow: 1;
+  flex-shrink: 1;
+  overflow: auto;
+  padding: 20px; }
+
+.navbar {
+  background-color: #ffffff;
+  min-height: 3.25rem;
+  position: relative;
+  z-index: 30; }
+  .navbar.is-white {
+    background-color: white;
+    color: #0a0a0a; }
+    .navbar.is-white .navbar-brand > .navbar-item,
+    .navbar.is-white .navbar-brand .navbar-link {
+      color: #0a0a0a; }
+    .navbar.is-white .navbar-brand > a.navbar-item:focus, .navbar.is-white .navbar-brand > a.navbar-item:hover, .navbar.is-white .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-white .navbar-brand .navbar-link:focus,
+    .navbar.is-white .navbar-brand .navbar-link:hover,
+    .navbar.is-white .navbar-brand .navbar-link.is-active {
+      background-color: #f2f2f2;
+      color: #0a0a0a; }
+    .navbar.is-white .navbar-brand .navbar-link::after {
+      border-color: #0a0a0a; }
+    .navbar.is-white .navbar-burger {
+      color: #0a0a0a; }
+    @media screen and (min-width: 1024px) {
+      .navbar.is-white .navbar-start > .navbar-item,
+      .navbar.is-white .navbar-start .navbar-link,
+      .navbar.is-white .navbar-end > .navbar-item,
+      .navbar.is-white .navbar-end .navbar-link {
+        color: #0a0a0a; }
+      .navbar.is-white .navbar-start > a.navbar-item:focus, .navbar.is-white .navbar-start > a.navbar-item:hover, .navbar.is-white .navbar-start > a.navbar-item.is-active,
+      .navbar.is-white .navbar-start .navbar-link:focus,
+      .navbar.is-white .navbar-start .navbar-link:hover,
+      .navbar.is-white .navbar-start .navbar-link.is-active,
+      .navbar.is-white .navbar-end > a.navbar-item:focus,
+      .navbar.is-white .navbar-end > a.navbar-item:hover,
+      .navbar.is-white .navbar-end > a.navbar-item.is-active,
+      .navbar.is-white .navbar-end .navbar-link:focus,
+      .navbar.is-white .navbar-end .navbar-link:hover,
+      .navbar.is-white .navbar-end .navbar-link.is-active {
+        background-color: #f2f2f2;
+        color: #0a0a0a; }
+      .navbar.is-white .navbar-start .navbar-link::after,
+      .navbar.is-white .navbar-end .navbar-link::after {
+        border-color: #0a0a0a; }
+      .navbar.is-white .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-white .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-white .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #f2f2f2;
+        color: #0a0a0a; }
+      .navbar.is-white .navbar-dropdown a.navbar-item.is-active {
+        background-color: white;
+        color: #0a0a0a; } }
+  .navbar.is-black {
+    background-color: #0a0a0a;
+    color: white; }
+    .navbar.is-black .navbar-brand > .navbar-item,
+    .navbar.is-black .navbar-brand .navbar-link {
+      color: white; }
+    .navbar.is-black .navbar-brand > a.navbar-item:focus, .navbar.is-black .navbar-brand > a.navbar-item:hover, .navbar.is-black .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-black .navbar-brand .navbar-link:focus,
+    .navbar.is-black .navbar-brand .navbar-link:hover,
+    .navbar.is-black .navbar-brand .navbar-link.is-active {
+      background-color: black;
+      color: white; }
+    .navbar.is-black .navbar-brand .navbar-link::after {
+      border-color: white; }
+    .navbar.is-black .navbar-burger {
+      color: white; }
+    @media screen and (min-width: 1024px) {
+      .navbar.is-black .navbar-start > .navbar-item,
+      .navbar.is-black .navbar-start .navbar-link,
+      .navbar.is-black .navbar-end > .navbar-item,
+      .navbar.is-black .navbar-end .navbar-link {
+        color: white; }
+      .navbar.is-black .navbar-start > a.navbar-item:focus, .navbar.is-black .navbar-start > a.navbar-item:hover, .navbar.is-black .navbar-start > a.navbar-item.is-active,
+      .navbar.is-black .navbar-start .navbar-link:focus,
+      .navbar.is-black .navbar-start .navbar-link:hover,
+      .navbar.is-black .navbar-start .navbar-link.is-active,
+      .navbar.is-black .navbar-end > a.navbar-item:focus,
+      .navbar.is-black .navbar-end > a.navbar-item:hover,
+      .navbar.is-black .navbar-end > a.navbar-item.is-active,
+      .navbar.is-black .navbar-end .navbar-link:focus,
+      .navbar.is-black .navbar-end .navbar-link:hover,
+      .navbar.is-black .navbar-end .navbar-link.is-active {
+        background-color: black;
+        color: white; }
+      .navbar.is-black .navbar-start .navbar-link::after,
+      .navbar.is-black .navbar-end .navbar-link::after {
+        border-color: white; }
+      .navbar.is-black .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-black .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-black .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: black;
+        color: white; }
+      .navbar.is-black .navbar-dropdown a.navbar-item.is-active {
+        background-color: #0a0a0a;
+        color: white; } }
+  .navbar.is-light {
+    background-color: whitesmoke;
+    color: rgba(0, 0, 0, 0.7); }
+    .navbar.is-light .navbar-brand > .navbar-item,
+    .navbar.is-light .navbar-brand .navbar-link {
+      color: rgba(0, 0, 0, 0.7); }
+    .navbar.is-light .navbar-brand > a.navbar-item:focus, .navbar.is-light .navbar-brand > a.navbar-item:hover, .navbar.is-light .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-light .navbar-brand .navbar-link:focus,
+    .navbar.is-light .navbar-brand .navbar-link:hover,
+    .navbar.is-light .navbar-brand .navbar-link.is-active {
+      background-color: #e8e8e8;
+      color: rgba(0, 0, 0, 0.7); }
+    .navbar.is-light .navbar-brand .navbar-link::after {
+      border-color: rgba(0, 0, 0, 0.7); }
+    .navbar.is-light .navbar-burger {
+      color: rgba(0, 0, 0, 0.7); }
+    @media screen and (min-width: 1024px) {
+      .navbar.is-light .navbar-start > .navbar-item,
+      .navbar.is-light .navbar-start .navbar-link,
+      .navbar.is-light .navbar-end > .navbar-item,
+      .navbar.is-light .navbar-end .navbar-link {
+        color: rgba(0, 0, 0, 0.7); }
+      .navbar.is-light .navbar-start > a.navbar-item:focus, .navbar.is-light .navbar-start > a.navbar-item:hover, .navbar.is-light .navbar-start > a.navbar-item.is-active,
+      .navbar.is-light .navbar-start .navbar-link:focus,
+      .navbar.is-light .navbar-start .navbar-link:hover,
+      .navbar.is-light .navbar-start .navbar-link.is-active,
+      .navbar.is-light .navbar-end > a.navbar-item:focus,
+      .navbar.is-light .navbar-end > a.navbar-item:hover,
+      .navbar.is-light .navbar-end > a.navbar-item.is-active,
+      .navbar.is-light .navbar-end .navbar-link:focus,
+      .navbar.is-light .navbar-end .navbar-link:hover,
+      .navbar.is-light .navbar-end .navbar-link.is-active {
+        background-color: #e8e8e8;
+        color: rgba(0, 0, 0, 0.7); }
+      .navbar.is-light .navbar-start .navbar-link::after,
+      .navbar.is-light .navbar-end .navbar-link::after {
+        border-color: rgba(0, 0, 0, 0.7); }
+      .navbar.is-light .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-light .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-light .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #e8e8e8;
+        color: rgba(0, 0, 0, 0.7); }
+      .navbar.is-light .navbar-dropdown a.navbar-item.is-active {
+        background-color: whitesmoke;
+        color: rgba(0, 0, 0, 0.7); } }
+  .navbar.is-dark {
+    background-color: #363636;
+    color: #fff; }
+    .navbar.is-dark .navbar-brand > .navbar-item,
+    .navbar.is-dark .navbar-brand .navbar-link {
+      color: #fff; }
+    .navbar.is-dark .navbar-brand > a.navbar-item:focus, .navbar.is-dark .navbar-brand > a.navbar-item:hover, .navbar.is-dark .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-dark .navbar-brand .navbar-link:focus,
+    .navbar.is-dark .navbar-brand .navbar-link:hover,
+    .navbar.is-dark .navbar-brand .navbar-link.is-active {
+      background-color: #292929;
+      color: #fff; }
+    .navbar.is-dark .navbar-brand .navbar-link::after {
+      border-color: #fff; }
+    .navbar.is-dark .navbar-burger {
+      color: #fff; }
+    @media screen and (min-width: 1024px) {
+      .navbar.is-dark .navbar-start > .navbar-item,
+      .navbar.is-dark .navbar-start .navbar-link,
+      .navbar.is-dark .navbar-end > .navbar-item,
+      .navbar.is-dark .navbar-end .navbar-link {
+        color: #fff; }
+      .navbar.is-dark .navbar-start > a.navbar-item:focus, .navbar.is-dark .navbar-start > a.navbar-item:hover, .navbar.is-dark .navbar-start > a.navbar-item.is-active,
+      .navbar.is-dark .navbar-start .navbar-link:focus,
+      .navbar.is-dark .navbar-start .navbar-link:hover,
+      .navbar.is-dark .navbar-start .navbar-link.is-active,
+      .navbar.is-dark .navbar-end > a.navbar-item:focus,
+      .navbar.is-dark .navbar-end > a.navbar-item:hover,
+      .navbar.is-dark .navbar-end > a.navbar-item.is-active,
+      .navbar.is-dark .navbar-end .navbar-link:focus,
+      .navbar.is-dark .navbar-end .navbar-link:hover,
+      .navbar.is-dark .navbar-end .navbar-link.is-active {
+        background-color: #292929;
+        color: #fff; }
+      .navbar.is-dark .navbar-start .navbar-link::after,
+      .navbar.is-dark .navbar-end .navbar-link::after {
+        border-color: #fff; }
+      .navbar.is-dark .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-dark .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-dark .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #292929;
+        color: #fff; }
+      .navbar.is-dark .navbar-dropdown a.navbar-item.is-active {
+        background-color: #363636;
+        color: #fff; } }
+  .navbar.is-primary {
+    background-color: #00b8d4;
+    color: #fff; }
+    .navbar.is-primary .navbar-brand > .navbar-item,
+    .navbar.is-primary .navbar-brand .navbar-link {
+      color: #fff; }
+    .navbar.is-primary .navbar-brand > a.navbar-item:focus, .navbar.is-primary .navbar-brand > a.navbar-item:hover, .navbar.is-primary .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-primary .navbar-brand .navbar-link:focus,
+    .navbar.is-primary .navbar-brand .navbar-link:hover,
+    .navbar.is-primary .navbar-brand .navbar-link.is-active {
+      background-color: #00a2bb;
+      color: #fff; }
+    .navbar.is-primary .navbar-brand .navbar-link::after {
+      border-color: #fff; }
+    .navbar.is-primary .navbar-burger {
+      color: #fff; }
+    @media screen and (min-width: 1024px) {
+      .navbar.is-primary .navbar-start > .navbar-item,
+      .navbar.is-primary .navbar-start .navbar-link,
+      .navbar.is-primary .navbar-end > .navbar-item,
+      .navbar.is-primary .navbar-end .navbar-link {
+        color: #fff; }
+      .navbar.is-primary .navbar-start > a.navbar-item:focus, .navbar.is-primary .navbar-start > a.navbar-item:hover, .navbar.is-primary .navbar-start > a.navbar-item.is-active,
+      .navbar.is-primary .navbar-start .navbar-link:focus,
+      .navbar.is-primary .navbar-start .navbar-link:hover,
+      .navbar.is-primary .navbar-start .navbar-link.is-active,
+      .navbar.is-primary .navbar-end > a.navbar-item:focus,
+      .navbar.is-primary .navbar-end > a.navbar-item:hover,
+      .navbar.is-primary .navbar-end > a.navbar-item.is-active,
+      .navbar.is-primary .navbar-end .navbar-link:focus,
+      .navbar.is-primary .navbar-end .navbar-link:hover,
+      .navbar.is-primary .navbar-end .navbar-link.is-active {
+        background-color: #00a2bb;
+        color: #fff; }
+      .navbar.is-primary .navbar-start .navbar-link::after,
+      .navbar.is-primary .navbar-end .navbar-link::after {
+        border-color: #fff; }
+      .navbar.is-primary .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-primary .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-primary .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #00a2bb;
+        color: #fff; }
+      .navbar.is-primary .navbar-dropdown a.navbar-item.is-active {
+        background-color: #00b8d4;
+        color: #fff; } }
+  .navbar.is-link {
+    background-color: #3273dc;
+    color: #fff; }
+    .navbar.is-link .navbar-brand > .navbar-item,
+    .navbar.is-link .navbar-brand .navbar-link {
+      color: #fff; }
+    .navbar.is-link .navbar-brand > a.navbar-item:focus, .navbar.is-link .navbar-brand > a.navbar-item:hover, .navbar.is-link .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-link .navbar-brand .navbar-link:focus,
+    .navbar.is-link .navbar-brand .navbar-link:hover,
+    .navbar.is-link .navbar-brand .navbar-link.is-active {
+      background-color: #2366d1;
+      color: #fff; }
+    .navbar.is-link .navbar-brand .navbar-link::after {
+      border-color: #fff; }
+    .navbar.is-link .navbar-burger {
+      color: #fff; }
+    @media screen and (min-width: 1024px) {
+      .navbar.is-link .navbar-start > .navbar-item,
+      .navbar.is-link .navbar-start .navbar-link,
+      .navbar.is-link .navbar-end > .navbar-item,
+      .navbar.is-link .navbar-end .navbar-link {
+        color: #fff; }
+      .navbar.is-link .navbar-start > a.navbar-item:focus, .navbar.is-link .navbar-start > a.navbar-item:hover, .navbar.is-link .navbar-start > a.navbar-item.is-active,
+      .navbar.is-link .navbar-start .navbar-link:focus,
+      .navbar.is-link .navbar-start .navbar-link:hover,
+      .navbar.is-link .navbar-start .navbar-link.is-active,
+      .navbar.is-link .navbar-end > a.navbar-item:focus,
+      .navbar.is-link .navbar-end > a.navbar-item:hover,
+      .navbar.is-link .navbar-end > a.navbar-item.is-active,
+      .navbar.is-link .navbar-end .navbar-link:focus,
+      .navbar.is-link .navbar-end .navbar-link:hover,
+      .navbar.is-link .navbar-end .navbar-link.is-active {
+        background-color: #2366d1;
+        color: #fff; }
+      .navbar.is-link .navbar-start .navbar-link::after,
+      .navbar.is-link .navbar-end .navbar-link::after {
+        border-color: #fff; }
+      .navbar.is-link .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-link .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-link .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #2366d1;
+        color: #fff; }
+      .navbar.is-link .navbar-dropdown a.navbar-item.is-active {
+        background-color: #3273dc;
+        color: #fff; } }
+  .navbar.is-info {
+    background-color: #3298dc;
+    color: #fff; }
+    .navbar.is-info .navbar-brand > .navbar-item,
+    .navbar.is-info .navbar-brand .navbar-link {
+      color: #fff; }
+    .navbar.is-info .navbar-brand > a.navbar-item:focus, .navbar.is-info .navbar-brand > a.navbar-item:hover, .navbar.is-info .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-info .navbar-brand .navbar-link:focus,
+    .navbar.is-info .navbar-brand .navbar-link:hover,
+    .navbar.is-info .navbar-brand .navbar-link.is-active {
+      background-color: #238cd1;
+      color: #fff; }
+    .navbar.is-info .navbar-brand .navbar-link::after {
+      border-color: #fff; }
+    .navbar.is-info .navbar-burger {
+      color: #fff; }
+    @media screen and (min-width: 1024px) {
+      .navbar.is-info .navbar-start > .navbar-item,
+      .navbar.is-info .navbar-start .navbar-link,
+      .navbar.is-info .navbar-end > .navbar-item,
+      .navbar.is-info .navbar-end .navbar-link {
+        color: #fff; }
+      .navbar.is-info .navbar-start > a.navbar-item:focus, .navbar.is-info .navbar-start > a.navbar-item:hover, .navbar.is-info .navbar-start > a.navbar-item.is-active,
+      .navbar.is-info .navbar-start .navbar-link:focus,
+      .navbar.is-info .navbar-start .navbar-link:hover,
+      .navbar.is-info .navbar-start .navbar-link.is-active,
+      .navbar.is-info .navbar-end > a.navbar-item:focus,
+      .navbar.is-info .navbar-end > a.navbar-item:hover,
+      .navbar.is-info .navbar-end > a.navbar-item.is-active,
+      .navbar.is-info .navbar-end .navbar-link:focus,
+      .navbar.is-info .navbar-end .navbar-link:hover,
+      .navbar.is-info .navbar-end .navbar-link.is-active {
+        background-color: #238cd1;
+        color: #fff; }
+      .navbar.is-info .navbar-start .navbar-link::after,
+      .navbar.is-info .navbar-end .navbar-link::after {
+        border-color: #fff; }
+      .navbar.is-info .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-info .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-info .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #238cd1;
+        color: #fff; }
+      .navbar.is-info .navbar-dropdown a.navbar-item.is-active {
+        background-color: #3298dc;
+        color: #fff; } }
+  .navbar.is-success {
+    background-color: #48c774;
+    color: #fff; }
+    .navbar.is-success .navbar-brand > .navbar-item,
+    .navbar.is-success .navbar-brand .navbar-link {
+      color: #fff; }
+    .navbar.is-success .navbar-brand > a.navbar-item:focus, .navbar.is-success .navbar-brand > a.navbar-item:hover, .navbar.is-success .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-success .navbar-brand .navbar-link:focus,
+    .navbar.is-success .navbar-brand .navbar-link:hover,
+    .navbar.is-success .navbar-brand .navbar-link.is-active {
+      background-color: #3abb67;
+      color: #fff; }
+    .navbar.is-success .navbar-brand .navbar-link::after {
+      border-color: #fff; }
+    .navbar.is-success .navbar-burger {
+      color: #fff; }
+    @media screen and (min-width: 1024px) {
+      .navbar.is-success .navbar-start > .navbar-item,
+      .navbar.is-success .navbar-start .navbar-link,
+      .navbar.is-success .navbar-end > .navbar-item,
+      .navbar.is-success .navbar-end .navbar-link {
+        color: #fff; }
+      .navbar.is-success .navbar-start > a.navbar-item:focus, .navbar.is-success .navbar-start > a.navbar-item:hover, .navbar.is-success .navbar-start > a.navbar-item.is-active,
+      .navbar.is-success .navbar-start .navbar-link:focus,
+      .navbar.is-success .navbar-start .navbar-link:hover,
+      .navbar.is-success .navbar-start .navbar-link.is-active,
+      .navbar.is-success .navbar-end > a.navbar-item:focus,
+      .navbar.is-success .navbar-end > a.navbar-item:hover,
+      .navbar.is-success .navbar-end > a.navbar-item.is-active,
+      .navbar.is-success .navbar-end .navbar-link:focus,
+      .navbar.is-success .navbar-end .navbar-link:hover,
+      .navbar.is-success .navbar-end .navbar-link.is-active {
+        background-color: #3abb67;
+        color: #fff; }
+      .navbar.is-success .navbar-start .navbar-link::after,
+      .navbar.is-success .navbar-end .navbar-link::after {
+        border-color: #fff; }
+      .navbar.is-success .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-success .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-success .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #3abb67;
+        color: #fff; }
+      .navbar.is-success .navbar-dropdown a.navbar-item.is-active {
+        background-color: #48c774;
+        color: #fff; } }
+  .navbar.is-warning {
+    background-color: #ffdd57;
+    color: rgba(0, 0, 0, 0.7); }
+    .navbar.is-warning .navbar-brand > .navbar-item,
+    .navbar.is-warning .navbar-brand .navbar-link {
+      color: rgba(0, 0, 0, 0.7); }
+    .navbar.is-warning .navbar-brand > a.navbar-item:focus, .navbar.is-warning .navbar-brand > a.navbar-item:hover, .navbar.is-warning .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-warning .navbar-brand .navbar-link:focus,
+    .navbar.is-warning .navbar-brand .navbar-link:hover,
+    .navbar.is-warning .navbar-brand .navbar-link.is-active {
+      background-color: #ffd83d;
+      color: rgba(0, 0, 0, 0.7); }
+    .navbar.is-warning .navbar-brand .navbar-link::after {
+      border-color: rgba(0, 0, 0, 0.7); }
+    .navbar.is-warning .navbar-burger {
+      color: rgba(0, 0, 0, 0.7); }
+    @media screen and (min-width: 1024px) {
+      .navbar.is-warning .navbar-start > .navbar-item,
+      .navbar.is-warning .navbar-start .navbar-link,
+      .navbar.is-warning .navbar-end > .navbar-item,
+      .navbar.is-warning .navbar-end .navbar-link {
+        color: rgba(0, 0, 0, 0.7); }
+      .navbar.is-warning .navbar-start > a.navbar-item:focus, .navbar.is-warning .navbar-start > a.navbar-item:hover, .navbar.is-warning .navbar-start > a.navbar-item.is-active,
+      .navbar.is-warning .navbar-start .navbar-link:focus,
+      .navbar.is-warning .navbar-start .navbar-link:hover,
+      .navbar.is-warning .navbar-start .navbar-link.is-active,
+      .navbar.is-warning .navbar-end > a.navbar-item:focus,
+      .navbar.is-warning .navbar-end > a.navbar-item:hover,
+      .navbar.is-warning .navbar-end > a.navbar-item.is-active,
+      .navbar.is-warning .navbar-end .navbar-link:focus,
+      .navbar.is-warning .navbar-end .navbar-link:hover,
+      .navbar.is-warning .navbar-end .navbar-link.is-active {
+        background-color: #ffd83d;
+        color: rgba(0, 0, 0, 0.7); }
+      .navbar.is-warning .navbar-start .navbar-link::after,
+      .navbar.is-warning .navbar-end .navbar-link::after {
+        border-color: rgba(0, 0, 0, 0.7); }
+      .navbar.is-warning .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-warning .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-warning .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #ffd83d;
+        color: rgba(0, 0, 0, 0.7); }
+      .navbar.is-warning .navbar-dropdown a.navbar-item.is-active {
+        background-color: #ffdd57;
+        color: rgba(0, 0, 0, 0.7); } }
+  .navbar.is-danger {
+    background-color: #f14668;
+    color: #fff; }
+    .navbar.is-danger .navbar-brand > .navbar-item,
+    .navbar.is-danger .navbar-brand .navbar-link {
+      color: #fff; }
+    .navbar.is-danger .navbar-brand > a.navbar-item:focus, .navbar.is-danger .navbar-brand > a.navbar-item:hover, .navbar.is-danger .navbar-brand > a.navbar-item.is-active,
+    .navbar.is-danger .navbar-brand .navbar-link:focus,
+    .navbar.is-danger .navbar-brand .navbar-link:hover,
+    .navbar.is-danger .navbar-brand .navbar-link.is-active {
+      background-color: #ef2e55;
+      color: #fff; }
+    .navbar.is-danger .navbar-brand .navbar-link::after {
+      border-color: #fff; }
+    .navbar.is-danger .navbar-burger {
+      color: #fff; }
+    @media screen and (min-width: 1024px) {
+      .navbar.is-danger .navbar-start > .navbar-item,
+      .navbar.is-danger .navbar-start .navbar-link,
+      .navbar.is-danger .navbar-end > .navbar-item,
+      .navbar.is-danger .navbar-end .navbar-link {
+        color: #fff; }
+      .navbar.is-danger .navbar-start > a.navbar-item:focus, .navbar.is-danger .navbar-start > a.navbar-item:hover, .navbar.is-danger .navbar-start > a.navbar-item.is-active,
+      .navbar.is-danger .navbar-start .navbar-link:focus,
+      .navbar.is-danger .navbar-start .navbar-link:hover,
+      .navbar.is-danger .navbar-start .navbar-link.is-active,
+      .navbar.is-danger .navbar-end > a.navbar-item:focus,
+      .navbar.is-danger .navbar-end > a.navbar-item:hover,
+      .navbar.is-danger .navbar-end > a.navbar-item.is-active,
+      .navbar.is-danger .navbar-end .navbar-link:focus,
+      .navbar.is-danger .navbar-end .navbar-link:hover,
+      .navbar.is-danger .navbar-end .navbar-link.is-active {
+        background-color: #ef2e55;
+        color: #fff; }
+      .navbar.is-danger .navbar-start .navbar-link::after,
+      .navbar.is-danger .navbar-end .navbar-link::after {
+        border-color: #fff; }
+      .navbar.is-danger .navbar-item.has-dropdown:focus .navbar-link,
+      .navbar.is-danger .navbar-item.has-dropdown:hover .navbar-link,
+      .navbar.is-danger .navbar-item.has-dropdown.is-active .navbar-link {
+        background-color: #ef2e55;
+        color: #fff; }
+      .navbar.is-danger .navbar-dropdown a.navbar-item.is-active {
+        background-color: #f14668;
+        color: #fff; } }
+  .navbar > .container {
+    align-items: stretch;
+    display: flex;
+    min-height: 3.25rem;
+    width: 100%; }
+  .navbar.has-shadow {
+    box-shadow: 0 2px 0 0 #ffffff; }
+  .navbar.is-fixed-bottom, .navbar.is-fixed-top {
+    left: 0;
+    position: fixed;
+    right: 0;
+    z-index: 30; }
+  .navbar.is-fixed-bottom {
+    bottom: 0; }
+    .navbar.is-fixed-bottom.has-shadow {
+      box-shadow: 0 -2px 0 0 #ffffff; }
+  .navbar.is-fixed-top {
+    top: 0; }
+
+html.has-navbar-fixed-top,
+body.has-navbar-fixed-top {
+  padding-top: 3.25rem; }
+
+html.has-navbar-fixed-bottom,
+body.has-navbar-fixed-bottom {
+  padding-bottom: 3.25rem; }
+
+.navbar-brand,
+.navbar-tabs {
+  align-items: stretch;
+  display: flex;
+  flex-shrink: 0;
+  min-height: 3.25rem; }
+
+.navbar-brand a.navbar-item:focus, .navbar-brand a.navbar-item:hover {
+  background-color: transparent; }
+
+.navbar-tabs {
+  -webkit-overflow-scrolling: touch;
+  max-width: 100vw;
+  overflow-x: auto;
+  overflow-y: hidden; }
+
+.navbar-burger {
+  color: #4a4a4a;
+  cursor: pointer;
+  display: block;
+  height: 3.25rem;
+  position: relative;
+  width: 3.25rem;
+  margin-left: auto; }
+  .navbar-burger span {
+    background-color: currentColor;
+    display: block;
+    height: 1px;
+    left: calc(50% - 8px);
+    position: absolute;
+    transform-origin: center;
+    transition-duration: 86ms;
+    transition-property: background-color, opacity, transform;
+    transition-timing-function: ease-out;
+    width: 16px; }
+    .navbar-burger span:nth-child(1) {
+      top: calc(50% - 6px); }
+    .navbar-burger span:nth-child(2) {
+      top: calc(50% - 1px); }
+    .navbar-burger span:nth-child(3) {
+      top: calc(50% + 4px); }
+  .navbar-burger:hover {
+    background-color: rgba(0, 0, 0, 0.05); }
+  .navbar-burger.is-active span:nth-child(1) {
+    transform: translateY(5px) rotate(45deg); }
+  .navbar-burger.is-active span:nth-child(2) {
+    opacity: 0; }
+  .navbar-burger.is-active span:nth-child(3) {
+    transform: translateY(-5px) rotate(-45deg); }
+
+.navbar-menu {
+  display: none; }
+
+.navbar-item,
+.navbar-link {
+  color: #4a4a4a;
+  display: block;
+  line-height: 1.5;
+  padding: 0.5rem 0.75rem;
+  position: relative; }
+  .navbar-item .icon:only-child,
+  .navbar-link .icon:only-child {
+    margin-left: -0.25rem;
+    margin-right: -0.25rem; }
+
+a.navbar-item,
+.navbar-link {
+  cursor: pointer; }
+  a.navbar-item:focus, a.navbar-item:focus-within, a.navbar-item:hover, a.navbar-item.is-active,
+  .navbar-link:focus,
+  .navbar-link:focus-within,
+  .navbar-link:hover,
+  .navbar-link.is-active {
+    background-color: #ffffff;
+    color: #dbdbdb; }
+
+.navbar-item {
+  flex-grow: 0;
+  flex-shrink: 0; }
+  .navbar-item img {
+    max-height: 1.75rem; }
+  .navbar-item.has-dropdown {
+    padding: 0; }
+  .navbar-item.is-expanded {
+    flex-grow: 1;
+    flex-shrink: 1; }
+  .navbar-item.is-tab {
+    border-bottom: 1px solid transparent;
+    min-height: 3.25rem;
+    padding-bottom: calc(0.5rem - 1px); }
+    .navbar-item.is-tab:focus, .navbar-item.is-tab:hover {
+      background-color: transparent;
+      border-bottom-color: #3273dc; }
+    .navbar-item.is-tab.is-active {
+      background-color: transparent;
+      border-bottom-color: #3273dc;
+      border-bottom-style: solid;
+      border-bottom-width: 3px;
+      color: #3273dc;
+      padding-bottom: calc(0.5rem - 3px); }
+
+.navbar-content {
+  flex-grow: 1;
+  flex-shrink: 1; }
+
+.navbar-link:not(.is-arrowless) {
+  padding-right: 2.5em; }
+  .navbar-link:not(.is-arrowless)::after {
+    border-color: #3273dc;
+    margin-top: -0.375em;
+    right: 1.125em; }
+
+.navbar-dropdown {
+  font-size: 0.875rem;
+  padding-bottom: 0.5rem;
+  padding-top: 0.5rem; }
+  .navbar-dropdown .navbar-item {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem; }
+
+.navbar-divider {
+  background-color: #ffffff;
+  border: none;
+  display: none;
+  height: 2px;
+  margin: 0.5rem 0; }
+
+@media screen and (max-width: 1023px) {
+  .navbar > .container {
+    display: block; }
+  .navbar-brand .navbar-item,
+  .navbar-tabs .navbar-item {
+    align-items: center;
+    display: flex; }
+  .navbar-link::after {
+    display: none; }
+  .navbar-menu {
+    background-color: #ffffff;
+    box-shadow: 0 8px 16px rgba(10, 10, 10, 0.1);
+    padding: 0.5rem 0; }
+    .navbar-menu.is-active {
+      display: block; }
+  .navbar.is-fixed-bottom-touch, .navbar.is-fixed-top-touch {
+    left: 0;
+    position: fixed;
+    right: 0;
+    z-index: 30; }
+  .navbar.is-fixed-bottom-touch {
+    bottom: 0; }
+    .navbar.is-fixed-bottom-touch.has-shadow {
+      box-shadow: 0 -2px 3px rgba(10, 10, 10, 0.1); }
+  .navbar.is-fixed-top-touch {
+    top: 0; }
+  .navbar.is-fixed-top .navbar-menu, .navbar.is-fixed-top-touch .navbar-menu {
+    -webkit-overflow-scrolling: touch;
+    max-height: calc(100vh - 3.25rem);
+    overflow: auto; }
+  html.has-navbar-fixed-top-touch,
+  body.has-navbar-fixed-top-touch {
+    padding-top: 3.25rem; }
+  html.has-navbar-fixed-bottom-touch,
+  body.has-navbar-fixed-bottom-touch {
+    padding-bottom: 3.25rem; } }
+
+@media screen and (min-width: 1024px) {
+  .navbar,
+  .navbar-menu,
+  .navbar-start,
+  .navbar-end {
+    align-items: stretch;
+    display: flex; }
+  .navbar {
+    min-height: 3.25rem; }
+    .navbar.is-spaced {
+      padding: 1rem 2rem; }
+      .navbar.is-spaced .navbar-start,
+      .navbar.is-spaced .navbar-end {
+        align-items: center; }
+      .navbar.is-spaced a.navbar-item,
+      .navbar.is-spaced .navbar-link {
+        border-radius: 4px; }
+    .navbar.is-transparent a.navbar-item:focus, .navbar.is-transparent a.navbar-item:hover, .navbar.is-transparent a.navbar-item.is-active,
+    .navbar.is-transparent .navbar-link:focus,
+    .navbar.is-transparent .navbar-link:hover,
+    .navbar.is-transparent .navbar-link.is-active {
+      background-color: transparent !important; }
+    .navbar.is-transparent .navbar-item.has-dropdown.is-active .navbar-link, .navbar.is-transparent .navbar-item.has-dropdown.is-hoverable:focus .navbar-link, .navbar.is-transparent .navbar-item.has-dropdown.is-hoverable:focus-within .navbar-link, .navbar.is-transparent .navbar-item.has-dropdown.is-hoverable:hover .navbar-link {
+      background-color: transparent !important; }
+    .navbar.is-transparent .navbar-dropdown a.navbar-item:focus, .navbar.is-transparent .navbar-dropdown a.navbar-item:hover {
+      background-color: #ffffff;
+      color: #0a0a0a; }
+    .navbar.is-transparent .navbar-dropdown a.navbar-item.is-active {
+      background-color: #ffffff;
+      color: #3273dc; }
+  .navbar-burger {
+    display: none; }
+  .navbar-item,
+  .navbar-link {
+    align-items: center;
+    display: flex; }
+  .navbar-item.has-dropdown {
+    align-items: stretch; }
+  .navbar-item.has-dropdown-up .navbar-link::after {
+    transform: rotate(135deg) translate(0.25em, -0.25em); }
+  .navbar-item.has-dropdown-up .navbar-dropdown {
+    border-bottom: 2px solid #dbdbdb;
+    border-radius: 6px 6px 0 0;
+    border-top: none;
+    bottom: 100%;
+    box-shadow: 0 -8px 8px rgba(10, 10, 10, 0.1);
+    top: auto; }
+  .navbar-item.is-active .navbar-dropdown, .navbar-item.is-hoverable:focus .navbar-dropdown, .navbar-item.is-hoverable:focus-within .navbar-dropdown, .navbar-item.is-hoverable:hover .navbar-dropdown {
+    display: block; }
+    .navbar.is-spaced .navbar-item.is-active .navbar-dropdown, .navbar-item.is-active .navbar-dropdown.is-boxed, .navbar.is-spaced .navbar-item.is-hoverable:focus .navbar-dropdown, .navbar-item.is-hoverable:focus .navbar-dropdown.is-boxed, .navbar.is-spaced .navbar-item.is-hoverable:focus-within .navbar-dropdown, .navbar-item.is-hoverable:focus-within .navbar-dropdown.is-boxed, .navbar.is-spaced .navbar-item.is-hoverable:hover .navbar-dropdown, .navbar-item.is-hoverable:hover .navbar-dropdown.is-boxed {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateY(0); }
+  .navbar-menu {
+    flex-grow: 1;
+    flex-shrink: 0; }
+  .navbar-start {
+    justify-content: flex-start;
+    margin-right: auto; }
+  .navbar-end {
+    justify-content: flex-end;
+    margin-left: auto; }
+  .navbar-dropdown {
+    background-color: white;
+    border-bottom-left-radius: 6px;
+    border-bottom-right-radius: 6px;
+    border-top: 2px solid #dbdbdb;
+    box-shadow: 0 8px 8px rgba(10, 10, 10, 0.1);
+    display: none;
+    font-size: 0.875rem;
+    left: 0;
+    min-width: 100%;
+    position: absolute;
+    top: 100%;
+    z-index: 20; }
+    .navbar-dropdown .navbar-item {
+      padding: 0.375rem 1rem;
+      white-space: nowrap; }
+    .navbar-dropdown a.navbar-item {
+      padding-right: 3rem; }
+      .navbar-dropdown a.navbar-item:focus, .navbar-dropdown a.navbar-item:hover {
+        background-color: #ffffff;
+        color: #0a0a0a; }
+      .navbar-dropdown a.navbar-item.is-active {
+        background-color: #ffffff;
+        color: #3273dc; }
+    .navbar.is-spaced .navbar-dropdown, .navbar-dropdown.is-boxed {
+      border-radius: 6px;
+      border-top: none;
+      box-shadow: 0 8px 8px rgba(10, 10, 10, 0.1), 0 0 0 1px rgba(10, 10, 10, 0.1);
+      display: block;
+      opacity: 0;
+      pointer-events: none;
+      top: calc(100% + (-4px));
+      transform: translateY(-5px);
+      transition-duration: 86ms;
+      transition-property: opacity, transform; }
+    .navbar-dropdown.is-right {
+      left: auto;
+      right: 0; }
+  .navbar-divider {
+    display: block; }
+  .navbar > .container .navbar-brand,
+  .container > .navbar .navbar-brand {
+    margin-left: -0.75rem; }
+  .navbar > .container .navbar-menu,
+  .container > .navbar .navbar-menu {
+    margin-right: -0.75rem; }
+  .navbar.is-fixed-bottom-desktop, .navbar.is-fixed-top-desktop {
+    left: 0;
+    position: fixed;
+    right: 0;
+    z-index: 30; }
+  .navbar.is-fixed-bottom-desktop {
+    bottom: 0; }
+    .navbar.is-fixed-bottom-desktop.has-shadow {
+      box-shadow: 0 -2px 3px rgba(10, 10, 10, 0.1); }
+  .navbar.is-fixed-top-desktop {
+    top: 0; }
+  html.has-navbar-fixed-top-desktop,
+  body.has-navbar-fixed-top-desktop {
+    padding-top: 3.25rem; }
+  html.has-navbar-fixed-bottom-desktop,
+  body.has-navbar-fixed-bottom-desktop {
+    padding-bottom: 3.25rem; }
+  html.has-spaced-navbar-fixed-top,
+  body.has-spaced-navbar-fixed-top {
+    padding-top: 5.25rem; }
+  html.has-spaced-navbar-fixed-bottom,
+  body.has-spaced-navbar-fixed-bottom {
+    padding-bottom: 5.25rem; }
+  a.navbar-item.is-active,
+  .navbar-link.is-active {
+    color: #0a0a0a; }
+  a.navbar-item.is-active:not(:focus):not(:hover),
+  .navbar-link.is-active:not(:focus):not(:hover) {
+    background-color: transparent; }
+  .navbar-item.has-dropdown:focus .navbar-link, .navbar-item.has-dropdown:hover .navbar-link, .navbar-item.has-dropdown.is-active .navbar-link {
+    background-color: #ffffff; } }
+
+.hero.is-fullheight-with-navbar {
+  min-height: calc(100vh - 3.25rem); }
+
+.column {
+  display: block;
+  flex-basis: 0;
+  flex-grow: 1;
+  flex-shrink: 1;
+  padding: 0.75rem; }
+  .columns.is-mobile > .column.is-narrow {
+    flex: none; }
+  .columns.is-mobile > .column.is-full {
+    flex: none;
+    width: 100%; }
+  .columns.is-mobile > .column.is-three-quarters {
+    flex: none;
+    width: 75%; }
+  .columns.is-mobile > .column.is-two-thirds {
+    flex: none;
+    width: 66.6666%; }
+  .columns.is-mobile > .column.is-half {
+    flex: none;
+    width: 50%; }
+  .columns.is-mobile > .column.is-one-third {
+    flex: none;
+    width: 33.3333%; }
+  .columns.is-mobile > .column.is-one-quarter {
+    flex: none;
+    width: 25%; }
+  .columns.is-mobile > .column.is-one-fifth {
+    flex: none;
+    width: 20%; }
+  .columns.is-mobile > .column.is-two-fifths {
+    flex: none;
+    width: 40%; }
+  .columns.is-mobile > .column.is-three-fifths {
+    flex: none;
+    width: 60%; }
+  .columns.is-mobile > .column.is-four-fifths {
+    flex: none;
+    width: 80%; }
+  .columns.is-mobile > .column.is-offset-three-quarters {
+    margin-left: 75%; }
+  .columns.is-mobile > .column.is-offset-two-thirds {
+    margin-left: 66.6666%; }
+  .columns.is-mobile > .column.is-offset-half {
+    margin-left: 50%; }
+  .columns.is-mobile > .column.is-offset-one-third {
+    margin-left: 33.3333%; }
+  .columns.is-mobile > .column.is-offset-one-quarter {
+    margin-left: 25%; }
+  .columns.is-mobile > .column.is-offset-one-fifth {
+    margin-left: 20%; }
+  .columns.is-mobile > .column.is-offset-two-fifths {
+    margin-left: 40%; }
+  .columns.is-mobile > .column.is-offset-three-fifths {
+    margin-left: 60%; }
+  .columns.is-mobile > .column.is-offset-four-fifths {
+    margin-left: 80%; }
+  .columns.is-mobile > .column.is-0 {
+    flex: none;
+    width: 0%; }
+  .columns.is-mobile > .column.is-offset-0 {
+    margin-left: 0%; }
+  .columns.is-mobile > .column.is-1 {
+    flex: none;
+    width: 8.33333333%; }
+  .columns.is-mobile > .column.is-offset-1 {
+    margin-left: 8.33333333%; }
+  .columns.is-mobile > .column.is-2 {
+    flex: none;
+    width: 16.66666667%; }
+  .columns.is-mobile > .column.is-offset-2 {
+    margin-left: 16.66666667%; }
+  .columns.is-mobile > .column.is-3 {
+    flex: none;
+    width: 25%; }
+  .columns.is-mobile > .column.is-offset-3 {
+    margin-left: 25%; }
+  .columns.is-mobile > .column.is-4 {
+    flex: none;
+    width: 33.33333333%; }
+  .columns.is-mobile > .column.is-offset-4 {
+    margin-left: 33.33333333%; }
+  .columns.is-mobile > .column.is-5 {
+    flex: none;
+    width: 41.66666667%; }
+  .columns.is-mobile > .column.is-offset-5 {
+    margin-left: 41.66666667%; }
+  .columns.is-mobile > .column.is-6 {
+    flex: none;
+    width: 50%; }
+  .columns.is-mobile > .column.is-offset-6 {
+    margin-left: 50%; }
+  .columns.is-mobile > .column.is-7 {
+    flex: none;
+    width: 58.33333333%; }
+  .columns.is-mobile > .column.is-offset-7 {
+    margin-left: 58.33333333%; }
+  .columns.is-mobile > .column.is-8 {
+    flex: none;
+    width: 66.66666667%; }
+  .columns.is-mobile > .column.is-offset-8 {
+    margin-left: 66.66666667%; }
+  .columns.is-mobile > .column.is-9 {
+    flex: none;
+    width: 75%; }
+  .columns.is-mobile > .column.is-offset-9 {
+    margin-left: 75%; }
+  .columns.is-mobile > .column.is-10 {
+    flex: none;
+    width: 83.33333333%; }
+  .columns.is-mobile > .column.is-offset-10 {
+    margin-left: 83.33333333%; }
+  .columns.is-mobile > .column.is-11 {
+    flex: none;
+    width: 91.66666667%; }
+  .columns.is-mobile > .column.is-offset-11 {
+    margin-left: 91.66666667%; }
+  .columns.is-mobile > .column.is-12 {
+    flex: none;
+    width: 100%; }
+  .columns.is-mobile > .column.is-offset-12 {
+    margin-left: 100%; }
+  @media screen and (max-width: 768px) {
+    .column.is-narrow-mobile {
+      flex: none; }
+    .column.is-full-mobile {
+      flex: none;
+      width: 100%; }
+    .column.is-three-quarters-mobile {
+      flex: none;
+      width: 75%; }
+    .column.is-two-thirds-mobile {
+      flex: none;
+      width: 66.6666%; }
+    .column.is-half-mobile {
+      flex: none;
+      width: 50%; }
+    .column.is-one-third-mobile {
+      flex: none;
+      width: 33.3333%; }
+    .column.is-one-quarter-mobile {
+      flex: none;
+      width: 25%; }
+    .column.is-one-fifth-mobile {
+      flex: none;
+      width: 20%; }
+    .column.is-two-fifths-mobile {
+      flex: none;
+      width: 40%; }
+    .column.is-three-fifths-mobile {
+      flex: none;
+      width: 60%; }
+    .column.is-four-fifths-mobile {
+      flex: none;
+      width: 80%; }
+    .column.is-offset-three-quarters-mobile {
+      margin-left: 75%; }
+    .column.is-offset-two-thirds-mobile {
+      margin-left: 66.6666%; }
+    .column.is-offset-half-mobile {
+      margin-left: 50%; }
+    .column.is-offset-one-third-mobile {
+      margin-left: 33.3333%; }
+    .column.is-offset-one-quarter-mobile {
+      margin-left: 25%; }
+    .column.is-offset-one-fifth-mobile {
+      margin-left: 20%; }
+    .column.is-offset-two-fifths-mobile {
+      margin-left: 40%; }
+    .column.is-offset-three-fifths-mobile {
+      margin-left: 60%; }
+    .column.is-offset-four-fifths-mobile {
+      margin-left: 80%; }
+    .column.is-0-mobile {
+      flex: none;
+      width: 0%; }
+    .column.is-offset-0-mobile {
+      margin-left: 0%; }
+    .column.is-1-mobile {
+      flex: none;
+      width: 8.33333333%; }
+    .column.is-offset-1-mobile {
+      margin-left: 8.33333333%; }
+    .column.is-2-mobile {
+      flex: none;
+      width: 16.66666667%; }
+    .column.is-offset-2-mobile {
+      margin-left: 16.66666667%; }
+    .column.is-3-mobile {
+      flex: none;
+      width: 25%; }
+    .column.is-offset-3-mobile {
+      margin-left: 25%; }
+    .column.is-4-mobile {
+      flex: none;
+      width: 33.33333333%; }
+    .column.is-offset-4-mobile {
+      margin-left: 33.33333333%; }
+    .column.is-5-mobile {
+      flex: none;
+      width: 41.66666667%; }
+    .column.is-offset-5-mobile {
+      margin-left: 41.66666667%; }
+    .column.is-6-mobile {
+      flex: none;
+      width: 50%; }
+    .column.is-offset-6-mobile {
+      margin-left: 50%; }
+    .column.is-7-mobile {
+      flex: none;
+      width: 58.33333333%; }
+    .column.is-offset-7-mobile {
+      margin-left: 58.33333333%; }
+    .column.is-8-mobile {
+      flex: none;
+      width: 66.66666667%; }
+    .column.is-offset-8-mobile {
+      margin-left: 66.66666667%; }
+    .column.is-9-mobile {
+      flex: none;
+      width: 75%; }
+    .column.is-offset-9-mobile {
+      margin-left: 75%; }
+    .column.is-10-mobile {
+      flex: none;
+      width: 83.33333333%; }
+    .column.is-offset-10-mobile {
+      margin-left: 83.33333333%; }
+    .column.is-11-mobile {
+      flex: none;
+      width: 91.66666667%; }
+    .column.is-offset-11-mobile {
+      margin-left: 91.66666667%; }
+    .column.is-12-mobile {
+      flex: none;
+      width: 100%; }
+    .column.is-offset-12-mobile {
+      margin-left: 100%; } }
+  @media screen and (min-width: 769px), print {
+    .column.is-narrow, .column.is-narrow-tablet {
+      flex: none; }
+    .column.is-full, .column.is-full-tablet {
+      flex: none;
+      width: 100%; }
+    .column.is-three-quarters, .column.is-three-quarters-tablet {
+      flex: none;
+      width: 75%; }
+    .column.is-two-thirds, .column.is-two-thirds-tablet {
+      flex: none;
+      width: 66.6666%; }
+    .column.is-half, .column.is-half-tablet {
+      flex: none;
+      width: 50%; }
+    .column.is-one-third, .column.is-one-third-tablet {
+      flex: none;
+      width: 33.3333%; }
+    .column.is-one-quarter, .column.is-one-quarter-tablet {
+      flex: none;
+      width: 25%; }
+    .column.is-one-fifth, .column.is-one-fifth-tablet {
+      flex: none;
+      width: 20%; }
+    .column.is-two-fifths, .column.is-two-fifths-tablet {
+      flex: none;
+      width: 40%; }
+    .column.is-three-fifths, .column.is-three-fifths-tablet {
+      flex: none;
+      width: 60%; }
+    .column.is-four-fifths, .column.is-four-fifths-tablet {
+      flex: none;
+      width: 80%; }
+    .column.is-offset-three-quarters, .column.is-offset-three-quarters-tablet {
+      margin-left: 75%; }
+    .column.is-offset-two-thirds, .column.is-offset-two-thirds-tablet {
+      margin-left: 66.6666%; }
+    .column.is-offset-half, .column.is-offset-half-tablet {
+      margin-left: 50%; }
+    .column.is-offset-one-third, .column.is-offset-one-third-tablet {
+      margin-left: 33.3333%; }
+    .column.is-offset-one-quarter, .column.is-offset-one-quarter-tablet {
+      margin-left: 25%; }
+    .column.is-offset-one-fifth, .column.is-offset-one-fifth-tablet {
+      margin-left: 20%; }
+    .column.is-offset-two-fifths, .column.is-offset-two-fifths-tablet {
+      margin-left: 40%; }
+    .column.is-offset-three-fifths, .column.is-offset-three-fifths-tablet {
+      margin-left: 60%; }
+    .column.is-offset-four-fifths, .column.is-offset-four-fifths-tablet {
+      margin-left: 80%; }
+    .column.is-0, .column.is-0-tablet {
+      flex: none;
+      width: 0%; }
+    .column.is-offset-0, .column.is-offset-0-tablet {
+      margin-left: 0%; }
+    .column.is-1, .column.is-1-tablet {
+      flex: none;
+      width: 8.33333333%; }
+    .column.is-offset-1, .column.is-offset-1-tablet {
+      margin-left: 8.33333333%; }
+    .column.is-2, .column.is-2-tablet {
+      flex: none;
+      width: 16.66666667%; }
+    .column.is-offset-2, .column.is-offset-2-tablet {
+      margin-left: 16.66666667%; }
+    .column.is-3, .column.is-3-tablet {
+      flex: none;
+      width: 25%; }
+    .column.is-offset-3, .column.is-offset-3-tablet {
+      margin-left: 25%; }
+    .column.is-4, .column.is-4-tablet {
+      flex: none;
+      width: 33.33333333%; }
+    .column.is-offset-4, .column.is-offset-4-tablet {
+      margin-left: 33.33333333%; }
+    .column.is-5, .column.is-5-tablet {
+      flex: none;
+      width: 41.66666667%; }
+    .column.is-offset-5, .column.is-offset-5-tablet {
+      margin-left: 41.66666667%; }
+    .column.is-6, .column.is-6-tablet {
+      flex: none;
+      width: 50%; }
+    .column.is-offset-6, .column.is-offset-6-tablet {
+      margin-left: 50%; }
+    .column.is-7, .column.is-7-tablet {
+      flex: none;
+      width: 58.33333333%; }
+    .column.is-offset-7, .column.is-offset-7-tablet {
+      margin-left: 58.33333333%; }
+    .column.is-8, .column.is-8-tablet {
+      flex: none;
+      width: 66.66666667%; }
+    .column.is-offset-8, .column.is-offset-8-tablet {
+      margin-left: 66.66666667%; }
+    .column.is-9, .column.is-9-tablet {
+      flex: none;
+      width: 75%; }
+    .column.is-offset-9, .column.is-offset-9-tablet {
+      margin-left: 75%; }
+    .column.is-10, .column.is-10-tablet {
+      flex: none;
+      width: 83.33333333%; }
+    .column.is-offset-10, .column.is-offset-10-tablet {
+      margin-left: 83.33333333%; }
+    .column.is-11, .column.is-11-tablet {
+      flex: none;
+      width: 91.66666667%; }
+    .column.is-offset-11, .column.is-offset-11-tablet {
+      margin-left: 91.66666667%; }
+    .column.is-12, .column.is-12-tablet {
+      flex: none;
+      width: 100%; }
+    .column.is-offset-12, .column.is-offset-12-tablet {
+      margin-left: 100%; } }
+  @media screen and (max-width: 1023px) {
+    .column.is-narrow-touch {
+      flex: none; }
+    .column.is-full-touch {
+      flex: none;
+      width: 100%; }
+    .column.is-three-quarters-touch {
+      flex: none;
+      width: 75%; }
+    .column.is-two-thirds-touch {
+      flex: none;
+      width: 66.6666%; }
+    .column.is-half-touch {
+      flex: none;
+      width: 50%; }
+    .column.is-one-third-touch {
+      flex: none;
+      width: 33.3333%; }
+    .column.is-one-quarter-touch {
+      flex: none;
+      width: 25%; }
+    .column.is-one-fifth-touch {
+      flex: none;
+      width: 20%; }
+    .column.is-two-fifths-touch {
+      flex: none;
+      width: 40%; }
+    .column.is-three-fifths-touch {
+      flex: none;
+      width: 60%; }
+    .column.is-four-fifths-touch {
+      flex: none;
+      width: 80%; }
+    .column.is-offset-three-quarters-touch {
+      margin-left: 75%; }
+    .column.is-offset-two-thirds-touch {
+      margin-left: 66.6666%; }
+    .column.is-offset-half-touch {
+      margin-left: 50%; }
+    .column.is-offset-one-third-touch {
+      margin-left: 33.3333%; }
+    .column.is-offset-one-quarter-touch {
+      margin-left: 25%; }
+    .column.is-offset-one-fifth-touch {
+      margin-left: 20%; }
+    .column.is-offset-two-fifths-touch {
+      margin-left: 40%; }
+    .column.is-offset-three-fifths-touch {
+      margin-left: 60%; }
+    .column.is-offset-four-fifths-touch {
+      margin-left: 80%; }
+    .column.is-0-touch {
+      flex: none;
+      width: 0%; }
+    .column.is-offset-0-touch {
+      margin-left: 0%; }
+    .column.is-1-touch {
+      flex: none;
+      width: 8.33333333%; }
+    .column.is-offset-1-touch {
+      margin-left: 8.33333333%; }
+    .column.is-2-touch {
+      flex: none;
+      width: 16.66666667%; }
+    .column.is-offset-2-touch {
+      margin-left: 16.66666667%; }
+    .column.is-3-touch {
+      flex: none;
+      width: 25%; }
+    .column.is-offset-3-touch {
+      margin-left: 25%; }
+    .column.is-4-touch {
+      flex: none;
+      width: 33.33333333%; }
+    .column.is-offset-4-touch {
+      margin-left: 33.33333333%; }
+    .column.is-5-touch {
+      flex: none;
+      width: 41.66666667%; }
+    .column.is-offset-5-touch {
+      margin-left: 41.66666667%; }
+    .column.is-6-touch {
+      flex: none;
+      width: 50%; }
+    .column.is-offset-6-touch {
+      margin-left: 50%; }
+    .column.is-7-touch {
+      flex: none;
+      width: 58.33333333%; }
+    .column.is-offset-7-touch {
+      margin-left: 58.33333333%; }
+    .column.is-8-touch {
+      flex: none;
+      width: 66.66666667%; }
+    .column.is-offset-8-touch {
+      margin-left: 66.66666667%; }
+    .column.is-9-touch {
+      flex: none;
+      width: 75%; }
+    .column.is-offset-9-touch {
+      margin-left: 75%; }
+    .column.is-10-touch {
+      flex: none;
+      width: 83.33333333%; }
+    .column.is-offset-10-touch {
+      margin-left: 83.33333333%; }
+    .column.is-11-touch {
+      flex: none;
+      width: 91.66666667%; }
+    .column.is-offset-11-touch {
+      margin-left: 91.66666667%; }
+    .column.is-12-touch {
+      flex: none;
+      width: 100%; }
+    .column.is-offset-12-touch {
+      margin-left: 100%; } }
+  @media screen and (min-width: 1024px) {
+    .column.is-narrow-desktop {
+      flex: none; }
+    .column.is-full-desktop {
+      flex: none;
+      width: 100%; }
+    .column.is-three-quarters-desktop {
+      flex: none;
+      width: 75%; }
+    .column.is-two-thirds-desktop {
+      flex: none;
+      width: 66.6666%; }
+    .column.is-half-desktop {
+      flex: none;
+      width: 50%; }
+    .column.is-one-third-desktop {
+      flex: none;
+      width: 33.3333%; }
+    .column.is-one-quarter-desktop {
+      flex: none;
+      width: 25%; }
+    .column.is-one-fifth-desktop {
+      flex: none;
+      width: 20%; }
+    .column.is-two-fifths-desktop {
+      flex: none;
+      width: 40%; }
+    .column.is-three-fifths-desktop {
+      flex: none;
+      width: 60%; }
+    .column.is-four-fifths-desktop {
+      flex: none;
+      width: 80%; }
+    .column.is-offset-three-quarters-desktop {
+      margin-left: 75%; }
+    .column.is-offset-two-thirds-desktop {
+      margin-left: 66.6666%; }
+    .column.is-offset-half-desktop {
+      margin-left: 50%; }
+    .column.is-offset-one-third-desktop {
+      margin-left: 33.3333%; }
+    .column.is-offset-one-quarter-desktop {
+      margin-left: 25%; }
+    .column.is-offset-one-fifth-desktop {
+      margin-left: 20%; }
+    .column.is-offset-two-fifths-desktop {
+      margin-left: 40%; }
+    .column.is-offset-three-fifths-desktop {
+      margin-left: 60%; }
+    .column.is-offset-four-fifths-desktop {
+      margin-left: 80%; }
+    .column.is-0-desktop {
+      flex: none;
+      width: 0%; }
+    .column.is-offset-0-desktop {
+      margin-left: 0%; }
+    .column.is-1-desktop {
+      flex: none;
+      width: 8.33333333%; }
+    .column.is-offset-1-desktop {
+      margin-left: 8.33333333%; }
+    .column.is-2-desktop {
+      flex: none;
+      width: 16.66666667%; }
+    .column.is-offset-2-desktop {
+      margin-left: 16.66666667%; }
+    .column.is-3-desktop {
+      flex: none;
+      width: 25%; }
+    .column.is-offset-3-desktop {
+      margin-left: 25%; }
+    .column.is-4-desktop {
+      flex: none;
+      width: 33.33333333%; }
+    .column.is-offset-4-desktop {
+      margin-left: 33.33333333%; }
+    .column.is-5-desktop {
+      flex: none;
+      width: 41.66666667%; }
+    .column.is-offset-5-desktop {
+      margin-left: 41.66666667%; }
+    .column.is-6-desktop {
+      flex: none;
+      width: 50%; }
+    .column.is-offset-6-desktop {
+      margin-left: 50%; }
+    .column.is-7-desktop {
+      flex: none;
+      width: 58.33333333%; }
+    .column.is-offset-7-desktop {
+      margin-left: 58.33333333%; }
+    .column.is-8-desktop {
+      flex: none;
+      width: 66.66666667%; }
+    .column.is-offset-8-desktop {
+      margin-left: 66.66666667%; }
+    .column.is-9-desktop {
+      flex: none;
+      width: 75%; }
+    .column.is-offset-9-desktop {
+      margin-left: 75%; }
+    .column.is-10-desktop {
+      flex: none;
+      width: 83.33333333%; }
+    .column.is-offset-10-desktop {
+      margin-left: 83.33333333%; }
+    .column.is-11-desktop {
+      flex: none;
+      width: 91.66666667%; }
+    .column.is-offset-11-desktop {
+      margin-left: 91.66666667%; }
+    .column.is-12-desktop {
+      flex: none;
+      width: 100%; }
+    .column.is-offset-12-desktop {
+      margin-left: 100%; } }
+  @media screen and (min-width: 1216px) {
+    .column.is-narrow-widescreen {
+      flex: none; }
+    .column.is-full-widescreen {
+      flex: none;
+      width: 100%; }
+    .column.is-three-quarters-widescreen {
+      flex: none;
+      width: 75%; }
+    .column.is-two-thirds-widescreen {
+      flex: none;
+      width: 66.6666%; }
+    .column.is-half-widescreen {
+      flex: none;
+      width: 50%; }
+    .column.is-one-third-widescreen {
+      flex: none;
+      width: 33.3333%; }
+    .column.is-one-quarter-widescreen {
+      flex: none;
+      width: 25%; }
+    .column.is-one-fifth-widescreen {
+      flex: none;
+      width: 20%; }
+    .column.is-two-fifths-widescreen {
+      flex: none;
+      width: 40%; }
+    .column.is-three-fifths-widescreen {
+      flex: none;
+      width: 60%; }
+    .column.is-four-fifths-widescreen {
+      flex: none;
+      width: 80%; }
+    .column.is-offset-three-quarters-widescreen {
+      margin-left: 75%; }
+    .column.is-offset-two-thirds-widescreen {
+      margin-left: 66.6666%; }
+    .column.is-offset-half-widescreen {
+      margin-left: 50%; }
+    .column.is-offset-one-third-widescreen {
+      margin-left: 33.3333%; }
+    .column.is-offset-one-quarter-widescreen {
+      margin-left: 25%; }
+    .column.is-offset-one-fifth-widescreen {
+      margin-left: 20%; }
+    .column.is-offset-two-fifths-widescreen {
+      margin-left: 40%; }
+    .column.is-offset-three-fifths-widescreen {
+      margin-left: 60%; }
+    .column.is-offset-four-fifths-widescreen {
+      margin-left: 80%; }
+    .column.is-0-widescreen {
+      flex: none;
+      width: 0%; }
+    .column.is-offset-0-widescreen {
+      margin-left: 0%; }
+    .column.is-1-widescreen {
+      flex: none;
+      width: 8.33333333%; }
+    .column.is-offset-1-widescreen {
+      margin-left: 8.33333333%; }
+    .column.is-2-widescreen {
+      flex: none;
+      width: 16.66666667%; }
+    .column.is-offset-2-widescreen {
+      margin-left: 16.66666667%; }
+    .column.is-3-widescreen {
+      flex: none;
+      width: 25%; }
+    .column.is-offset-3-widescreen {
+      margin-left: 25%; }
+    .column.is-4-widescreen {
+      flex: none;
+      width: 33.33333333%; }
+    .column.is-offset-4-widescreen {
+      margin-left: 33.33333333%; }
+    .column.is-5-widescreen {
+      flex: none;
+      width: 41.66666667%; }
+    .column.is-offset-5-widescreen {
+      margin-left: 41.66666667%; }
+    .column.is-6-widescreen {
+      flex: none;
+      width: 50%; }
+    .column.is-offset-6-widescreen {
+      margin-left: 50%; }
+    .column.is-7-widescreen {
+      flex: none;
+      width: 58.33333333%; }
+    .column.is-offset-7-widescreen {
+      margin-left: 58.33333333%; }
+    .column.is-8-widescreen {
+      flex: none;
+      width: 66.66666667%; }
+    .column.is-offset-8-widescreen {
+      margin-left: 66.66666667%; }
+    .column.is-9-widescreen {
+      flex: none;
+      width: 75%; }
+    .column.is-offset-9-widescreen {
+      margin-left: 75%; }
+    .column.is-10-widescreen {
+      flex: none;
+      width: 83.33333333%; }
+    .column.is-offset-10-widescreen {
+      margin-left: 83.33333333%; }
+    .column.is-11-widescreen {
+      flex: none;
+      width: 91.66666667%; }
+    .column.is-offset-11-widescreen {
+      margin-left: 91.66666667%; }
+    .column.is-12-widescreen {
+      flex: none;
+      width: 100%; }
+    .column.is-offset-12-widescreen {
+      margin-left: 100%; } }
+  @media screen and (min-width: 1408px) {
+    .column.is-narrow-fullhd {
+      flex: none; }
+    .column.is-full-fullhd {
+      flex: none;
+      width: 100%; }
+    .column.is-three-quarters-fullhd {
+      flex: none;
+      width: 75%; }
+    .column.is-two-thirds-fullhd {
+      flex: none;
+      width: 66.6666%; }
+    .column.is-half-fullhd {
+      flex: none;
+      width: 50%; }
+    .column.is-one-third-fullhd {
+      flex: none;
+      width: 33.3333%; }
+    .column.is-one-quarter-fullhd {
+      flex: none;
+      width: 25%; }
+    .column.is-one-fifth-fullhd {
+      flex: none;
+      width: 20%; }
+    .column.is-two-fifths-fullhd {
+      flex: none;
+      width: 40%; }
+    .column.is-three-fifths-fullhd {
+      flex: none;
+      width: 60%; }
+    .column.is-four-fifths-fullhd {
+      flex: none;
+      width: 80%; }
+    .column.is-offset-three-quarters-fullhd {
+      margin-left: 75%; }
+    .column.is-offset-two-thirds-fullhd {
+      margin-left: 66.6666%; }
+    .column.is-offset-half-fullhd {
+      margin-left: 50%; }
+    .column.is-offset-one-third-fullhd {
+      margin-left: 33.3333%; }
+    .column.is-offset-one-quarter-fullhd {
+      margin-left: 25%; }
+    .column.is-offset-one-fifth-fullhd {
+      margin-left: 20%; }
+    .column.is-offset-two-fifths-fullhd {
+      margin-left: 40%; }
+    .column.is-offset-three-fifths-fullhd {
+      margin-left: 60%; }
+    .column.is-offset-four-fifths-fullhd {
+      margin-left: 80%; }
+    .column.is-0-fullhd {
+      flex: none;
+      width: 0%; }
+    .column.is-offset-0-fullhd {
+      margin-left: 0%; }
+    .column.is-1-fullhd {
+      flex: none;
+      width: 8.33333333%; }
+    .column.is-offset-1-fullhd {
+      margin-left: 8.33333333%; }
+    .column.is-2-fullhd {
+      flex: none;
+      width: 16.66666667%; }
+    .column.is-offset-2-fullhd {
+      margin-left: 16.66666667%; }
+    .column.is-3-fullhd {
+      flex: none;
+      width: 25%; }
+    .column.is-offset-3-fullhd {
+      margin-left: 25%; }
+    .column.is-4-fullhd {
+      flex: none;
+      width: 33.33333333%; }
+    .column.is-offset-4-fullhd {
+      margin-left: 33.33333333%; }
+    .column.is-5-fullhd {
+      flex: none;
+      width: 41.66666667%; }
+    .column.is-offset-5-fullhd {
+      margin-left: 41.66666667%; }
+    .column.is-6-fullhd {
+      flex: none;
+      width: 50%; }
+    .column.is-offset-6-fullhd {
+      margin-left: 50%; }
+    .column.is-7-fullhd {
+      flex: none;
+      width: 58.33333333%; }
+    .column.is-offset-7-fullhd {
+      margin-left: 58.33333333%; }
+    .column.is-8-fullhd {
+      flex: none;
+      width: 66.66666667%; }
+    .column.is-offset-8-fullhd {
+      margin-left: 66.66666667%; }
+    .column.is-9-fullhd {
+      flex: none;
+      width: 75%; }
+    .column.is-offset-9-fullhd {
+      margin-left: 75%; }
+    .column.is-10-fullhd {
+      flex: none;
+      width: 83.33333333%; }
+    .column.is-offset-10-fullhd {
+      margin-left: 83.33333333%; }
+    .column.is-11-fullhd {
+      flex: none;
+      width: 91.66666667%; }
+    .column.is-offset-11-fullhd {
+      margin-left: 91.66666667%; }
+    .column.is-12-fullhd {
+      flex: none;
+      width: 100%; }
+    .column.is-offset-12-fullhd {
+      margin-left: 100%; } }
+.columns {
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+  margin-top: -0.75rem; }
+  .columns:last-child {
+    margin-bottom: -0.75rem; }
+  .columns:not(:last-child) {
+    margin-bottom: calc(1.5rem - 0.75rem); }
+  .columns.is-centered {
+    justify-content: center; }
+  .columns.is-gapless {
+    margin-left: 0;
+    margin-right: 0;
+    margin-top: 0; }
+    .columns.is-gapless > .column {
+      margin: 0;
+      padding: 0 !important; }
+    .columns.is-gapless:not(:last-child) {
+      margin-bottom: 1.5rem; }
+    .columns.is-gapless:last-child {
+      margin-bottom: 0; }
+  .columns.is-mobile {
+    display: flex; }
+  .columns.is-multiline {
+    flex-wrap: wrap; }
+  .columns.is-vcentered {
+    align-items: center; }
+  @media screen and (min-width: 769px), print {
+    .columns:not(.is-desktop) {
+      display: flex; } }
+  @media screen and (min-width: 1024px) {
+    .columns.is-desktop {
+      display: flex; } }
+.columns.is-variable {
+  --columnGap: 0.75rem;
+  margin-left: calc(-1 * var(--columnGap));
+  margin-right: calc(-1 * var(--columnGap)); }
+  .columns.is-variable .column {
+    padding-left: var(--columnGap);
+    padding-right: var(--columnGap); }
+  .columns.is-variable.is-0 {
+    --columnGap: 0rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-0-mobile {
+      --columnGap: 0rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-0-tablet {
+      --columnGap: 0rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1023px) {
+    .columns.is-variable.is-0-tablet-only {
+      --columnGap: 0rem; } }
+  @media screen and (max-width: 1023px) {
+    .columns.is-variable.is-0-touch {
+      --columnGap: 0rem; } }
+  @media screen and (min-width: 1024px) {
+    .columns.is-variable.is-0-desktop {
+      --columnGap: 0rem; } }
+  @media screen and (min-width: 1024px) and (max-width: 1215px) {
+    .columns.is-variable.is-0-desktop-only {
+      --columnGap: 0rem; } }
+  @media screen and (min-width: 1216px) {
+    .columns.is-variable.is-0-widescreen {
+      --columnGap: 0rem; } }
+  @media screen and (min-width: 1216px) and (max-width: 1407px) {
+    .columns.is-variable.is-0-widescreen-only {
+      --columnGap: 0rem; } }
+  @media screen and (min-width: 1408px) {
+    .columns.is-variable.is-0-fullhd {
+      --columnGap: 0rem; } }
+  .columns.is-variable.is-1 {
+    --columnGap: 0.25rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-1-mobile {
+      --columnGap: 0.25rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-1-tablet {
+      --columnGap: 0.25rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1023px) {
+    .columns.is-variable.is-1-tablet-only {
+      --columnGap: 0.25rem; } }
+  @media screen and (max-width: 1023px) {
+    .columns.is-variable.is-1-touch {
+      --columnGap: 0.25rem; } }
+  @media screen and (min-width: 1024px) {
+    .columns.is-variable.is-1-desktop {
+      --columnGap: 0.25rem; } }
+  @media screen and (min-width: 1024px) and (max-width: 1215px) {
+    .columns.is-variable.is-1-desktop-only {
+      --columnGap: 0.25rem; } }
+  @media screen and (min-width: 1216px) {
+    .columns.is-variable.is-1-widescreen {
+      --columnGap: 0.25rem; } }
+  @media screen and (min-width: 1216px) and (max-width: 1407px) {
+    .columns.is-variable.is-1-widescreen-only {
+      --columnGap: 0.25rem; } }
+  @media screen and (min-width: 1408px) {
+    .columns.is-variable.is-1-fullhd {
+      --columnGap: 0.25rem; } }
+  .columns.is-variable.is-2 {
+    --columnGap: 0.5rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-2-mobile {
+      --columnGap: 0.5rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-2-tablet {
+      --columnGap: 0.5rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1023px) {
+    .columns.is-variable.is-2-tablet-only {
+      --columnGap: 0.5rem; } }
+  @media screen and (max-width: 1023px) {
+    .columns.is-variable.is-2-touch {
+      --columnGap: 0.5rem; } }
+  @media screen and (min-width: 1024px) {
+    .columns.is-variable.is-2-desktop {
+      --columnGap: 0.5rem; } }
+  @media screen and (min-width: 1024px) and (max-width: 1215px) {
+    .columns.is-variable.is-2-desktop-only {
+      --columnGap: 0.5rem; } }
+  @media screen and (min-width: 1216px) {
+    .columns.is-variable.is-2-widescreen {
+      --columnGap: 0.5rem; } }
+  @media screen and (min-width: 1216px) and (max-width: 1407px) {
+    .columns.is-variable.is-2-widescreen-only {
+      --columnGap: 0.5rem; } }
+  @media screen and (min-width: 1408px) {
+    .columns.is-variable.is-2-fullhd {
+      --columnGap: 0.5rem; } }
+  .columns.is-variable.is-3 {
+    --columnGap: 0.75rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-3-mobile {
+      --columnGap: 0.75rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-3-tablet {
+      --columnGap: 0.75rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1023px) {
+    .columns.is-variable.is-3-tablet-only {
+      --columnGap: 0.75rem; } }
+  @media screen and (max-width: 1023px) {
+    .columns.is-variable.is-3-touch {
+      --columnGap: 0.75rem; } }
+  @media screen and (min-width: 1024px) {
+    .columns.is-variable.is-3-desktop {
+      --columnGap: 0.75rem; } }
+  @media screen and (min-width: 1024px) and (max-width: 1215px) {
+    .columns.is-variable.is-3-desktop-only {
+      --columnGap: 0.75rem; } }
+  @media screen and (min-width: 1216px) {
+    .columns.is-variable.is-3-widescreen {
+      --columnGap: 0.75rem; } }
+  @media screen and (min-width: 1216px) and (max-width: 1407px) {
+    .columns.is-variable.is-3-widescreen-only {
+      --columnGap: 0.75rem; } }
+  @media screen and (min-width: 1408px) {
+    .columns.is-variable.is-3-fullhd {
+      --columnGap: 0.75rem; } }
+  .columns.is-variable.is-4 {
+    --columnGap: 1rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-4-mobile {
+      --columnGap: 1rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-4-tablet {
+      --columnGap: 1rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1023px) {
+    .columns.is-variable.is-4-tablet-only {
+      --columnGap: 1rem; } }
+  @media screen and (max-width: 1023px) {
+    .columns.is-variable.is-4-touch {
+      --columnGap: 1rem; } }
+  @media screen and (min-width: 1024px) {
+    .columns.is-variable.is-4-desktop {
+      --columnGap: 1rem; } }
+  @media screen and (min-width: 1024px) and (max-width: 1215px) {
+    .columns.is-variable.is-4-desktop-only {
+      --columnGap: 1rem; } }
+  @media screen and (min-width: 1216px) {
+    .columns.is-variable.is-4-widescreen {
+      --columnGap: 1rem; } }
+  @media screen and (min-width: 1216px) and (max-width: 1407px) {
+    .columns.is-variable.is-4-widescreen-only {
+      --columnGap: 1rem; } }
+  @media screen and (min-width: 1408px) {
+    .columns.is-variable.is-4-fullhd {
+      --columnGap: 1rem; } }
+  .columns.is-variable.is-5 {
+    --columnGap: 1.25rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-5-mobile {
+      --columnGap: 1.25rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-5-tablet {
+      --columnGap: 1.25rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1023px) {
+    .columns.is-variable.is-5-tablet-only {
+      --columnGap: 1.25rem; } }
+  @media screen and (max-width: 1023px) {
+    .columns.is-variable.is-5-touch {
+      --columnGap: 1.25rem; } }
+  @media screen and (min-width: 1024px) {
+    .columns.is-variable.is-5-desktop {
+      --columnGap: 1.25rem; } }
+  @media screen and (min-width: 1024px) and (max-width: 1215px) {
+    .columns.is-variable.is-5-desktop-only {
+      --columnGap: 1.25rem; } }
+  @media screen and (min-width: 1216px) {
+    .columns.is-variable.is-5-widescreen {
+      --columnGap: 1.25rem; } }
+  @media screen and (min-width: 1216px) and (max-width: 1407px) {
+    .columns.is-variable.is-5-widescreen-only {
+      --columnGap: 1.25rem; } }
+  @media screen and (min-width: 1408px) {
+    .columns.is-variable.is-5-fullhd {
+      --columnGap: 1.25rem; } }
+  .columns.is-variable.is-6 {
+    --columnGap: 1.5rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-6-mobile {
+      --columnGap: 1.5rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-6-tablet {
+      --columnGap: 1.5rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1023px) {
+    .columns.is-variable.is-6-tablet-only {
+      --columnGap: 1.5rem; } }
+  @media screen and (max-width: 1023px) {
+    .columns.is-variable.is-6-touch {
+      --columnGap: 1.5rem; } }
+  @media screen and (min-width: 1024px) {
+    .columns.is-variable.is-6-desktop {
+      --columnGap: 1.5rem; } }
+  @media screen and (min-width: 1024px) and (max-width: 1215px) {
+    .columns.is-variable.is-6-desktop-only {
+      --columnGap: 1.5rem; } }
+  @media screen and (min-width: 1216px) {
+    .columns.is-variable.is-6-widescreen {
+      --columnGap: 1.5rem; } }
+  @media screen and (min-width: 1216px) and (max-width: 1407px) {
+    .columns.is-variable.is-6-widescreen-only {
+      --columnGap: 1.5rem; } }
+  @media screen and (min-width: 1408px) {
+    .columns.is-variable.is-6-fullhd {
+      --columnGap: 1.5rem; } }
+  .columns.is-variable.is-7 {
+    --columnGap: 1.75rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-7-mobile {
+      --columnGap: 1.75rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-7-tablet {
+      --columnGap: 1.75rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1023px) {
+    .columns.is-variable.is-7-tablet-only {
+      --columnGap: 1.75rem; } }
+  @media screen and (max-width: 1023px) {
+    .columns.is-variable.is-7-touch {
+      --columnGap: 1.75rem; } }
+  @media screen and (min-width: 1024px) {
+    .columns.is-variable.is-7-desktop {
+      --columnGap: 1.75rem; } }
+  @media screen and (min-width: 1024px) and (max-width: 1215px) {
+    .columns.is-variable.is-7-desktop-only {
+      --columnGap: 1.75rem; } }
+  @media screen and (min-width: 1216px) {
+    .columns.is-variable.is-7-widescreen {
+      --columnGap: 1.75rem; } }
+  @media screen and (min-width: 1216px) and (max-width: 1407px) {
+    .columns.is-variable.is-7-widescreen-only {
+      --columnGap: 1.75rem; } }
+  @media screen and (min-width: 1408px) {
+    .columns.is-variable.is-7-fullhd {
+      --columnGap: 1.75rem; } }
+  .columns.is-variable.is-8 {
+    --columnGap: 2rem; }
+  @media screen and (max-width: 768px) {
+    .columns.is-variable.is-8-mobile {
+      --columnGap: 2rem; } }
+  @media screen and (min-width: 769px), print {
+    .columns.is-variable.is-8-tablet {
+      --columnGap: 2rem; } }
+  @media screen and (min-width: 769px) and (max-width: 1023px) {
+    .columns.is-variable.is-8-tablet-only {
+      --columnGap: 2rem; } }
+  @media screen and (max-width: 1023px) {
+    .columns.is-variable.is-8-touch {
+      --columnGap: 2rem; } }
+  @media screen and (min-width: 1024px) {
+    .columns.is-variable.is-8-desktop {
+      --columnGap: 2rem; } }
+  @media screen and (min-width: 1024px) and (max-width: 1215px) {
+    .columns.is-variable.is-8-desktop-only {
+      --columnGap: 2rem; } }
+  @media screen and (min-width: 1216px) {
+    .columns.is-variable.is-8-widescreen {
+      --columnGap: 2rem; } }
+  @media screen and (min-width: 1216px) and (max-width: 1407px) {
+    .columns.is-variable.is-8-widescreen-only {
+      --columnGap: 2rem; } }
+  @media screen and (min-width: 1408px) {
+    .columns.is-variable.is-8-fullhd {
+      --columnGap: 2rem; } }
+.hero {
+  align-items: stretch;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between; }
+  .hero .navbar {
+    background: none; }
+  .hero .tabs ul {
+    border-bottom: none; }
+  .hero.is-white {
+    background-color: white;
+    color: #0a0a0a; }
+    .hero.is-white a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-white strong {
+      color: inherit; }
+    .hero.is-white .title {
+      color: #0a0a0a; }
+    .hero.is-white .subtitle {
+      color: rgba(10, 10, 10, 0.9); }
+      .hero.is-white .subtitle a:not(.button),
+      .hero.is-white .subtitle strong {
+        color: #0a0a0a; }
+    @media screen and (max-width: 1023px) {
+      .hero.is-white .navbar-menu {
+        background-color: white; } }
+    .hero.is-white .navbar-item,
+    .hero.is-white .navbar-link {
+      color: rgba(10, 10, 10, 0.7); }
+    .hero.is-white a.navbar-item:hover, .hero.is-white a.navbar-item.is-active,
+    .hero.is-white .navbar-link:hover,
+    .hero.is-white .navbar-link.is-active {
+      background-color: #f2f2f2;
+      color: #0a0a0a; }
+    .hero.is-white .tabs a {
+      color: #0a0a0a;
+      opacity: 0.9; }
+      .hero.is-white .tabs a:hover {
+        opacity: 1; }
+    .hero.is-white .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-white .tabs.is-boxed a, .hero.is-white .tabs.is-toggle a {
+      color: #0a0a0a; }
+      .hero.is-white .tabs.is-boxed a:hover, .hero.is-white .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-white .tabs.is-boxed li.is-active a, .hero.is-white .tabs.is-boxed li.is-active a:hover, .hero.is-white .tabs.is-toggle li.is-active a, .hero.is-white .tabs.is-toggle li.is-active a:hover {
+      background-color: #0a0a0a;
+      border-color: #0a0a0a;
+      color: white; }
+    .hero.is-white.is-bold {
+      background-image: linear-gradient(141deg, #e8e3e4 0%, white 71%, white 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-white.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #e8e3e4 0%, white 71%, white 100%); } }
+  .hero.is-black {
+    background-color: #0a0a0a;
+    color: white; }
+    .hero.is-black a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-black strong {
+      color: inherit; }
+    .hero.is-black .title {
+      color: white; }
+    .hero.is-black .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-black .subtitle a:not(.button),
+      .hero.is-black .subtitle strong {
+        color: white; }
+    @media screen and (max-width: 1023px) {
+      .hero.is-black .navbar-menu {
+        background-color: #0a0a0a; } }
+    .hero.is-black .navbar-item,
+    .hero.is-black .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-black a.navbar-item:hover, .hero.is-black a.navbar-item.is-active,
+    .hero.is-black .navbar-link:hover,
+    .hero.is-black .navbar-link.is-active {
+      background-color: black;
+      color: white; }
+    .hero.is-black .tabs a {
+      color: white;
+      opacity: 0.9; }
+      .hero.is-black .tabs a:hover {
+        opacity: 1; }
+    .hero.is-black .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-black .tabs.is-boxed a, .hero.is-black .tabs.is-toggle a {
+      color: white; }
+      .hero.is-black .tabs.is-boxed a:hover, .hero.is-black .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-black .tabs.is-boxed li.is-active a, .hero.is-black .tabs.is-boxed li.is-active a:hover, .hero.is-black .tabs.is-toggle li.is-active a, .hero.is-black .tabs.is-toggle li.is-active a:hover {
+      background-color: white;
+      border-color: white;
+      color: #0a0a0a; }
+    .hero.is-black.is-bold {
+      background-image: linear-gradient(141deg, black 0%, #0a0a0a 71%, #181616 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-black.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, black 0%, #0a0a0a 71%, #181616 100%); } }
+  .hero.is-light {
+    background-color: whitesmoke;
+    color: rgba(0, 0, 0, 0.7); }
+    .hero.is-light a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-light strong {
+      color: inherit; }
+    .hero.is-light .title {
+      color: rgba(0, 0, 0, 0.7); }
+    .hero.is-light .subtitle {
+      color: rgba(0, 0, 0, 0.9); }
+      .hero.is-light .subtitle a:not(.button),
+      .hero.is-light .subtitle strong {
+        color: rgba(0, 0, 0, 0.7); }
+    @media screen and (max-width: 1023px) {
+      .hero.is-light .navbar-menu {
+        background-color: whitesmoke; } }
+    .hero.is-light .navbar-item,
+    .hero.is-light .navbar-link {
+      color: rgba(0, 0, 0, 0.7); }
+    .hero.is-light a.navbar-item:hover, .hero.is-light a.navbar-item.is-active,
+    .hero.is-light .navbar-link:hover,
+    .hero.is-light .navbar-link.is-active {
+      background-color: #e8e8e8;
+      color: rgba(0, 0, 0, 0.7); }
+    .hero.is-light .tabs a {
+      color: rgba(0, 0, 0, 0.7);
+      opacity: 0.9; }
+      .hero.is-light .tabs a:hover {
+        opacity: 1; }
+    .hero.is-light .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-light .tabs.is-boxed a, .hero.is-light .tabs.is-toggle a {
+      color: rgba(0, 0, 0, 0.7); }
+      .hero.is-light .tabs.is-boxed a:hover, .hero.is-light .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-light .tabs.is-boxed li.is-active a, .hero.is-light .tabs.is-boxed li.is-active a:hover, .hero.is-light .tabs.is-toggle li.is-active a, .hero.is-light .tabs.is-toggle li.is-active a:hover {
+      background-color: rgba(0, 0, 0, 0.7);
+      border-color: rgba(0, 0, 0, 0.7);
+      color: whitesmoke; }
+    .hero.is-light.is-bold {
+      background-image: linear-gradient(141deg, #dfd8d9 0%, whitesmoke 71%, white 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-light.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #dfd8d9 0%, whitesmoke 71%, white 100%); } }
+  .hero.is-dark {
+    background-color: #363636;
+    color: #fff; }
+    .hero.is-dark a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-dark strong {
+      color: inherit; }
+    .hero.is-dark .title {
+      color: #fff; }
+    .hero.is-dark .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-dark .subtitle a:not(.button),
+      .hero.is-dark .subtitle strong {
+        color: #fff; }
+    @media screen and (max-width: 1023px) {
+      .hero.is-dark .navbar-menu {
+        background-color: #363636; } }
+    .hero.is-dark .navbar-item,
+    .hero.is-dark .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-dark a.navbar-item:hover, .hero.is-dark a.navbar-item.is-active,
+    .hero.is-dark .navbar-link:hover,
+    .hero.is-dark .navbar-link.is-active {
+      background-color: #292929;
+      color: #fff; }
+    .hero.is-dark .tabs a {
+      color: #fff;
+      opacity: 0.9; }
+      .hero.is-dark .tabs a:hover {
+        opacity: 1; }
+    .hero.is-dark .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-dark .tabs.is-boxed a, .hero.is-dark .tabs.is-toggle a {
+      color: #fff; }
+      .hero.is-dark .tabs.is-boxed a:hover, .hero.is-dark .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-dark .tabs.is-boxed li.is-active a, .hero.is-dark .tabs.is-boxed li.is-active a:hover, .hero.is-dark .tabs.is-toggle li.is-active a, .hero.is-dark .tabs.is-toggle li.is-active a:hover {
+      background-color: #fff;
+      border-color: #fff;
+      color: #363636; }
+    .hero.is-dark.is-bold {
+      background-image: linear-gradient(141deg, #1f191a 0%, #363636 71%, #46403f 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-dark.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #1f191a 0%, #363636 71%, #46403f 100%); } }
+  .hero.is-primary {
+    background-color: #00b8d4;
+    color: #fff; }
+    .hero.is-primary a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-primary strong {
+      color: inherit; }
+    .hero.is-primary .title {
+      color: #fff; }
+    .hero.is-primary .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-primary .subtitle a:not(.button),
+      .hero.is-primary .subtitle strong {
+        color: #fff; }
+    @media screen and (max-width: 1023px) {
+      .hero.is-primary .navbar-menu {
+        background-color: #00b8d4; } }
+    .hero.is-primary .navbar-item,
+    .hero.is-primary .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-primary a.navbar-item:hover, .hero.is-primary a.navbar-item.is-active,
+    .hero.is-primary .navbar-link:hover,
+    .hero.is-primary .navbar-link.is-active {
+      background-color: #00a2bb;
+      color: #fff; }
+    .hero.is-primary .tabs a {
+      color: #fff;
+      opacity: 0.9; }
+      .hero.is-primary .tabs a:hover {
+        opacity: 1; }
+    .hero.is-primary .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-primary .tabs.is-boxed a, .hero.is-primary .tabs.is-toggle a {
+      color: #fff; }
+      .hero.is-primary .tabs.is-boxed a:hover, .hero.is-primary .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-primary .tabs.is-boxed li.is-active a, .hero.is-primary .tabs.is-boxed li.is-active a:hover, .hero.is-primary .tabs.is-toggle li.is-active a, .hero.is-primary .tabs.is-toggle li.is-active a:hover {
+      background-color: #fff;
+      border-color: #fff;
+      color: #00b8d4; }
+    .hero.is-primary.is-bold {
+      background-image: linear-gradient(141deg, #00a19b 0%, #00b8d4 71%, #00a7ee 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-primary.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #00a19b 0%, #00b8d4 71%, #00a7ee 100%); } }
+  .hero.is-link {
+    background-color: #3273dc;
+    color: #fff; }
+    .hero.is-link a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-link strong {
+      color: inherit; }
+    .hero.is-link .title {
+      color: #fff; }
+    .hero.is-link .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-link .subtitle a:not(.button),
+      .hero.is-link .subtitle strong {
+        color: #fff; }
+    @media screen and (max-width: 1023px) {
+      .hero.is-link .navbar-menu {
+        background-color: #3273dc; } }
+    .hero.is-link .navbar-item,
+    .hero.is-link .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-link a.navbar-item:hover, .hero.is-link a.navbar-item.is-active,
+    .hero.is-link .navbar-link:hover,
+    .hero.is-link .navbar-link.is-active {
+      background-color: #2366d1;
+      color: #fff; }
+    .hero.is-link .tabs a {
+      color: #fff;
+      opacity: 0.9; }
+      .hero.is-link .tabs a:hover {
+        opacity: 1; }
+    .hero.is-link .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-link .tabs.is-boxed a, .hero.is-link .tabs.is-toggle a {
+      color: #fff; }
+      .hero.is-link .tabs.is-boxed a:hover, .hero.is-link .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-link .tabs.is-boxed li.is-active a, .hero.is-link .tabs.is-boxed li.is-active a:hover, .hero.is-link .tabs.is-toggle li.is-active a, .hero.is-link .tabs.is-toggle li.is-active a:hover {
+      background-color: #fff;
+      border-color: #fff;
+      color: #3273dc; }
+    .hero.is-link.is-bold {
+      background-image: linear-gradient(141deg, #1577c6 0%, #3273dc 71%, #4366e5 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-link.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #1577c6 0%, #3273dc 71%, #4366e5 100%); } }
+  .hero.is-info {
+    background-color: #3298dc;
+    color: #fff; }
+    .hero.is-info a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-info strong {
+      color: inherit; }
+    .hero.is-info .title {
+      color: #fff; }
+    .hero.is-info .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-info .subtitle a:not(.button),
+      .hero.is-info .subtitle strong {
+        color: #fff; }
+    @media screen and (max-width: 1023px) {
+      .hero.is-info .navbar-menu {
+        background-color: #3298dc; } }
+    .hero.is-info .navbar-item,
+    .hero.is-info .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-info a.navbar-item:hover, .hero.is-info a.navbar-item.is-active,
+    .hero.is-info .navbar-link:hover,
+    .hero.is-info .navbar-link.is-active {
+      background-color: #238cd1;
+      color: #fff; }
+    .hero.is-info .tabs a {
+      color: #fff;
+      opacity: 0.9; }
+      .hero.is-info .tabs a:hover {
+        opacity: 1; }
+    .hero.is-info .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-info .tabs.is-boxed a, .hero.is-info .tabs.is-toggle a {
+      color: #fff; }
+      .hero.is-info .tabs.is-boxed a:hover, .hero.is-info .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-info .tabs.is-boxed li.is-active a, .hero.is-info .tabs.is-boxed li.is-active a:hover, .hero.is-info .tabs.is-toggle li.is-active a, .hero.is-info .tabs.is-toggle li.is-active a:hover {
+      background-color: #fff;
+      border-color: #fff;
+      color: #3298dc; }
+    .hero.is-info.is-bold {
+      background-image: linear-gradient(141deg, #159dc6 0%, #3298dc 71%, #4389e5 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-info.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #159dc6 0%, #3298dc 71%, #4389e5 100%); } }
+  .hero.is-success {
+    background-color: #48c774;
+    color: #fff; }
+    .hero.is-success a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-success strong {
+      color: inherit; }
+    .hero.is-success .title {
+      color: #fff; }
+    .hero.is-success .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-success .subtitle a:not(.button),
+      .hero.is-success .subtitle strong {
+        color: #fff; }
+    @media screen and (max-width: 1023px) {
+      .hero.is-success .navbar-menu {
+        background-color: #48c774; } }
+    .hero.is-success .navbar-item,
+    .hero.is-success .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-success a.navbar-item:hover, .hero.is-success a.navbar-item.is-active,
+    .hero.is-success .navbar-link:hover,
+    .hero.is-success .navbar-link.is-active {
+      background-color: #3abb67;
+      color: #fff; }
+    .hero.is-success .tabs a {
+      color: #fff;
+      opacity: 0.9; }
+      .hero.is-success .tabs a:hover {
+        opacity: 1; }
+    .hero.is-success .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-success .tabs.is-boxed a, .hero.is-success .tabs.is-toggle a {
+      color: #fff; }
+      .hero.is-success .tabs.is-boxed a:hover, .hero.is-success .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-success .tabs.is-boxed li.is-active a, .hero.is-success .tabs.is-boxed li.is-active a:hover, .hero.is-success .tabs.is-toggle li.is-active a, .hero.is-success .tabs.is-toggle li.is-active a:hover {
+      background-color: #fff;
+      border-color: #fff;
+      color: #48c774; }
+    .hero.is-success.is-bold {
+      background-image: linear-gradient(141deg, #29b342 0%, #48c774 71%, #56d296 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-success.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #29b342 0%, #48c774 71%, #56d296 100%); } }
+  .hero.is-warning {
+    background-color: #ffdd57;
+    color: rgba(0, 0, 0, 0.7); }
+    .hero.is-warning a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-warning strong {
+      color: inherit; }
+    .hero.is-warning .title {
+      color: rgba(0, 0, 0, 0.7); }
+    .hero.is-warning .subtitle {
+      color: rgba(0, 0, 0, 0.9); }
+      .hero.is-warning .subtitle a:not(.button),
+      .hero.is-warning .subtitle strong {
+        color: rgba(0, 0, 0, 0.7); }
+    @media screen and (max-width: 1023px) {
+      .hero.is-warning .navbar-menu {
+        background-color: #ffdd57; } }
+    .hero.is-warning .navbar-item,
+    .hero.is-warning .navbar-link {
+      color: rgba(0, 0, 0, 0.7); }
+    .hero.is-warning a.navbar-item:hover, .hero.is-warning a.navbar-item.is-active,
+    .hero.is-warning .navbar-link:hover,
+    .hero.is-warning .navbar-link.is-active {
+      background-color: #ffd83d;
+      color: rgba(0, 0, 0, 0.7); }
+    .hero.is-warning .tabs a {
+      color: rgba(0, 0, 0, 0.7);
+      opacity: 0.9; }
+      .hero.is-warning .tabs a:hover {
+        opacity: 1; }
+    .hero.is-warning .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-warning .tabs.is-boxed a, .hero.is-warning .tabs.is-toggle a {
+      color: rgba(0, 0, 0, 0.7); }
+      .hero.is-warning .tabs.is-boxed a:hover, .hero.is-warning .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-warning .tabs.is-boxed li.is-active a, .hero.is-warning .tabs.is-boxed li.is-active a:hover, .hero.is-warning .tabs.is-toggle li.is-active a, .hero.is-warning .tabs.is-toggle li.is-active a:hover {
+      background-color: rgba(0, 0, 0, 0.7);
+      border-color: rgba(0, 0, 0, 0.7);
+      color: #ffdd57; }
+    .hero.is-warning.is-bold {
+      background-image: linear-gradient(141deg, #ffaf24 0%, #ffdd57 71%, #fffa70 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-warning.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #ffaf24 0%, #ffdd57 71%, #fffa70 100%); } }
+  .hero.is-danger {
+    background-color: #f14668;
+    color: #fff; }
+    .hero.is-danger a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+    .hero.is-danger strong {
+      color: inherit; }
+    .hero.is-danger .title {
+      color: #fff; }
+    .hero.is-danger .subtitle {
+      color: rgba(255, 255, 255, 0.9); }
+      .hero.is-danger .subtitle a:not(.button),
+      .hero.is-danger .subtitle strong {
+        color: #fff; }
+    @media screen and (max-width: 1023px) {
+      .hero.is-danger .navbar-menu {
+        background-color: #f14668; } }
+    .hero.is-danger .navbar-item,
+    .hero.is-danger .navbar-link {
+      color: rgba(255, 255, 255, 0.7); }
+    .hero.is-danger a.navbar-item:hover, .hero.is-danger a.navbar-item.is-active,
+    .hero.is-danger .navbar-link:hover,
+    .hero.is-danger .navbar-link.is-active {
+      background-color: #ef2e55;
+      color: #fff; }
+    .hero.is-danger .tabs a {
+      color: #fff;
+      opacity: 0.9; }
+      .hero.is-danger .tabs a:hover {
+        opacity: 1; }
+    .hero.is-danger .tabs li.is-active a {
+      opacity: 1; }
+    .hero.is-danger .tabs.is-boxed a, .hero.is-danger .tabs.is-toggle a {
+      color: #fff; }
+      .hero.is-danger .tabs.is-boxed a:hover, .hero.is-danger .tabs.is-toggle a:hover {
+        background-color: rgba(10, 10, 10, 0.1); }
+    .hero.is-danger .tabs.is-boxed li.is-active a, .hero.is-danger .tabs.is-boxed li.is-active a:hover, .hero.is-danger .tabs.is-toggle li.is-active a, .hero.is-danger .tabs.is-toggle li.is-active a:hover {
+      background-color: #fff;
+      border-color: #fff;
+      color: #f14668; }
+    .hero.is-danger.is-bold {
+      background-image: linear-gradient(141deg, #fa0a62 0%, #f14668 71%, #f7595f 100%); }
+      @media screen and (max-width: 768px) {
+        .hero.is-danger.is-bold .navbar-menu {
+          background-image: linear-gradient(141deg, #fa0a62 0%, #f14668 71%, #f7595f 100%); } }
+  .hero.is-small .hero-body {
+    padding: 1.5rem; }
+  @media screen and (min-width: 769px), print {
+    .hero.is-medium .hero-body {
+      padding: 9rem 1.5rem; } }
+  @media screen and (min-width: 769px), print {
+    .hero.is-large .hero-body {
+      padding: 18rem 1.5rem; } }
+  .hero.is-halfheight .hero-body, .hero.is-fullheight .hero-body, .hero.is-fullheight-with-navbar .hero-body {
+    align-items: center;
+    display: flex; }
+    .hero.is-halfheight .hero-body > .container, .hero.is-fullheight .hero-body > .container, .hero.is-fullheight-with-navbar .hero-body > .container {
+      flex-grow: 1;
+      flex-shrink: 1; }
+  .hero.is-halfheight {
+    min-height: 50vh; }
+  .hero.is-fullheight {
+    min-height: 100vh; }
+
+.hero-video {
+  overflow: hidden; }
+  .hero-video video {
+    left: 50%;
+    min-height: 100%;
+    min-width: 100%;
+    position: absolute;
+    top: 50%;
+    transform: translate3d(-50%, -50%, 0); }
+  .hero-video.is-transparent {
+    opacity: 0.3; }
+  @media screen and (max-width: 768px) {
+    .hero-video {
+      display: none; } }
+.hero-buttons {
+  margin-top: 1.5rem; }
+  @media screen and (max-width: 768px) {
+    .hero-buttons .button {
+      display: flex; }
+      .hero-buttons .button:not(:last-child) {
+        margin-bottom: 0.75rem; } }
+  @media screen and (min-width: 769px), print {
+    .hero-buttons {
+      display: flex;
+      justify-content: center; }
+      .hero-buttons .button:not(:last-child) {
+        margin-right: 1.5rem; } }
+.hero-head,
+.hero-foot {
+  flex-grow: 0;
+  flex-shrink: 0; }
+
+.hero-body {
+  flex-grow: 1;
+  flex-shrink: 0;
+  padding: 3rem 1.5rem; }
+
+.section {
+  padding: 3rem 1.5rem; }
+  @media screen and (min-width: 1024px) {
+    .section.is-medium {
+      padding: 9rem 1.5rem; }
+    .section.is-large {
+      padding: 18rem 1.5rem; } }
+.footer {
+  background-color: #fafafa;
+  padding: 3rem 1.5rem 6rem; }
+
+/*!
+ * Font Awesome Free 5.15.3 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+ */
+.fa,
+.fas,
+.far,
+.fal,
+.fad,
+.fab {
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  font-style: normal;
+  font-variant: normal;
+  text-rendering: auto;
+  line-height: 1; }
+
+.fa-lg {
+  font-size: 1.33333333em;
+  line-height: 0.75em;
+  vertical-align: -.0667em; }
+
+.fa-xs {
+  font-size: .75em; }
+
+.fa-sm {
+  font-size: .875em; }
+
+.fa-1x {
+  font-size: 1em; }
+
+.fa-2x {
+  font-size: 2em; }
+
+.fa-3x {
+  font-size: 3em; }
+
+.fa-4x {
+  font-size: 4em; }
+
+.fa-5x {
+  font-size: 5em; }
+
+.fa-6x {
+  font-size: 6em; }
+
+.fa-7x {
+  font-size: 7em; }
+
+.fa-8x {
+  font-size: 8em; }
+
+.fa-9x {
+  font-size: 9em; }
+
+.fa-10x {
+  font-size: 10em; }
+
+.fa-fw {
+  text-align: center;
+  width: 1.25em; }
+
+.fa-ul {
+  list-style-type: none;
+  margin-left: 2.5em;
+  padding-left: 0; }
+  .fa-ul > li {
+    position: relative; }
+
+.fa-li {
+  left: -2em;
+  position: absolute;
+  text-align: center;
+  width: 2em;
+  line-height: inherit; }
+
+.fa-border {
+  border: solid 0.08em #eee;
+  border-radius: .1em;
+  padding: .2em .25em .15em; }
+
+.fa-pull-left {
+  float: left; }
+
+.fa-pull-right {
+  float: right; }
+
+.fa.fa-pull-left,
+.fas.fa-pull-left,
+.far.fa-pull-left,
+.fal.fa-pull-left,
+.fab.fa-pull-left {
+  margin-right: .3em; }
+
+.fa.fa-pull-right,
+.fas.fa-pull-right,
+.far.fa-pull-right,
+.fal.fa-pull-right,
+.fab.fa-pull-right {
+  margin-left: .3em; }
+
+.fa-spin {
+  animation: fa-spin 2s infinite linear; }
+
+.fa-pulse {
+  animation: fa-spin 1s infinite steps(8); }
+
+@keyframes fa-spin {
+  0% {
+    transform: rotate(0deg); }
+  100% {
+    transform: rotate(360deg); } }
+
+.fa-rotate-90 {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=1)";
+  transform: rotate(90deg); }
+
+.fa-rotate-180 {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2)";
+  transform: rotate(180deg); }
+
+.fa-rotate-270 {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=3)";
+  transform: rotate(270deg); }
+
+.fa-flip-horizontal {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1)";
+  transform: scale(-1, 1); }
+
+.fa-flip-vertical {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1)";
+  transform: scale(1, -1); }
+
+.fa-flip-both, .fa-flip-horizontal.fa-flip-vertical {
+  -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1)";
+  transform: scale(-1, -1); }
+
+:root .fa-rotate-90,
+:root .fa-rotate-180,
+:root .fa-rotate-270,
+:root .fa-flip-horizontal,
+:root .fa-flip-vertical,
+:root .fa-flip-both {
+  filter: none; }
+
+.fa-stack {
+  display: inline-block;
+  height: 2em;
+  line-height: 2em;
+  position: relative;
+  vertical-align: middle;
+  width: 2.5em; }
+
+.fa-stack-1x,
+.fa-stack-2x {
+  left: 0;
+  position: absolute;
+  text-align: center;
+  width: 100%; }
+
+.fa-stack-1x {
+  line-height: inherit; }
+
+.fa-stack-2x {
+  font-size: 2em; }
+
+.fa-inverse {
+  color: #fff; }
+
+/* Font Awesome uses the Unicode Private Use Area (PUA) to ensure screen
+readers do not read off random characters that represent icons */
+.fa-500px:before {
+  content: "\f26e"; }
+
+.fa-accessible-icon:before {
+  content: "\f368"; }
+
+.fa-accusoft:before {
+  content: "\f369"; }
+
+.fa-acquisitions-incorporated:before {
+  content: "\f6af"; }
+
+.fa-ad:before {
+  content: "\f641"; }
+
+.fa-address-book:before {
+  content: "\f2b9"; }
+
+.fa-address-card:before {
+  content: "\f2bb"; }
+
+.fa-adjust:before {
+  content: "\f042"; }
+
+.fa-adn:before {
+  content: "\f170"; }
+
+.fa-adversal:before {
+  content: "\f36a"; }
+
+.fa-affiliatetheme:before {
+  content: "\f36b"; }
+
+.fa-air-freshener:before {
+  content: "\f5d0"; }
+
+.fa-airbnb:before {
+  content: "\f834"; }
+
+.fa-algolia:before {
+  content: "\f36c"; }
+
+.fa-align-center:before {
+  content: "\f037"; }
+
+.fa-align-justify:before {
+  content: "\f039"; }
+
+.fa-align-left:before {
+  content: "\f036"; }
+
+.fa-align-right:before {
+  content: "\f038"; }
+
+.fa-alipay:before {
+  content: "\f642"; }
+
+.fa-allergies:before {
+  content: "\f461"; }
+
+.fa-amazon:before {
+  content: "\f270"; }
+
+.fa-amazon-pay:before {
+  content: "\f42c"; }
+
+.fa-ambulance:before {
+  content: "\f0f9"; }
+
+.fa-american-sign-language-interpreting:before {
+  content: "\f2a3"; }
+
+.fa-amilia:before {
+  content: "\f36d"; }
+
+.fa-anchor:before {
+  content: "\f13d"; }
+
+.fa-android:before {
+  content: "\f17b"; }
+
+.fa-angellist:before {
+  content: "\f209"; }
+
+.fa-angle-double-down:before {
+  content: "\f103"; }
+
+.fa-angle-double-left:before {
+  content: "\f100"; }
+
+.fa-angle-double-right:before {
+  content: "\f101"; }
+
+.fa-angle-double-up:before {
+  content: "\f102"; }
+
+.fa-angle-down:before {
+  content: "\f107"; }
+
+.fa-angle-left:before {
+  content: "\f104"; }
+
+.fa-angle-right:before {
+  content: "\f105"; }
+
+.fa-angle-up:before {
+  content: "\f106"; }
+
+.fa-angry:before {
+  content: "\f556"; }
+
+.fa-angrycreative:before {
+  content: "\f36e"; }
+
+.fa-angular:before {
+  content: "\f420"; }
+
+.fa-ankh:before {
+  content: "\f644"; }
+
+.fa-app-store:before {
+  content: "\f36f"; }
+
+.fa-app-store-ios:before {
+  content: "\f370"; }
+
+.fa-apper:before {
+  content: "\f371"; }
+
+.fa-apple:before {
+  content: "\f179"; }
+
+.fa-apple-alt:before {
+  content: "\f5d1"; }
+
+.fa-apple-pay:before {
+  content: "\f415"; }
+
+.fa-archive:before {
+  content: "\f187"; }
+
+.fa-archway:before {
+  content: "\f557"; }
+
+.fa-arrow-alt-circle-down:before {
+  content: "\f358"; }
+
+.fa-arrow-alt-circle-left:before {
+  content: "\f359"; }
+
+.fa-arrow-alt-circle-right:before {
+  content: "\f35a"; }
+
+.fa-arrow-alt-circle-up:before {
+  content: "\f35b"; }
+
+.fa-arrow-circle-down:before {
+  content: "\f0ab"; }
+
+.fa-arrow-circle-left:before {
+  content: "\f0a8"; }
+
+.fa-arrow-circle-right:before {
+  content: "\f0a9"; }
+
+.fa-arrow-circle-up:before {
+  content: "\f0aa"; }
+
+.fa-arrow-down:before {
+  content: "\f063"; }
+
+.fa-arrow-left:before {
+  content: "\f060"; }
+
+.fa-arrow-right:before {
+  content: "\f061"; }
+
+.fa-arrow-up:before {
+  content: "\f062"; }
+
+.fa-arrows-alt:before {
+  content: "\f0b2"; }
+
+.fa-arrows-alt-h:before {
+  content: "\f337"; }
+
+.fa-arrows-alt-v:before {
+  content: "\f338"; }
+
+.fa-artstation:before {
+  content: "\f77a"; }
+
+.fa-assistive-listening-systems:before {
+  content: "\f2a2"; }
+
+.fa-asterisk:before {
+  content: "\f069"; }
+
+.fa-asymmetrik:before {
+  content: "\f372"; }
+
+.fa-at:before {
+  content: "\f1fa"; }
+
+.fa-atlas:before {
+  content: "\f558"; }
+
+.fa-atlassian:before {
+  content: "\f77b"; }
+
+.fa-atom:before {
+  content: "\f5d2"; }
+
+.fa-audible:before {
+  content: "\f373"; }
+
+.fa-audio-description:before {
+  content: "\f29e"; }
+
+.fa-autoprefixer:before {
+  content: "\f41c"; }
+
+.fa-avianex:before {
+  content: "\f374"; }
+
+.fa-aviato:before {
+  content: "\f421"; }
+
+.fa-award:before {
+  content: "\f559"; }
+
+.fa-aws:before {
+  content: "\f375"; }
+
+.fa-baby:before {
+  content: "\f77c"; }
+
+.fa-baby-carriage:before {
+  content: "\f77d"; }
+
+.fa-backspace:before {
+  content: "\f55a"; }
+
+.fa-backward:before {
+  content: "\f04a"; }
+
+.fa-bacon:before {
+  content: "\f7e5"; }
+
+.fa-bacteria:before {
+  content: "\e059"; }
+
+.fa-bacterium:before {
+  content: "\e05a"; }
+
+.fa-bahai:before {
+  content: "\f666"; }
+
+.fa-balance-scale:before {
+  content: "\f24e"; }
+
+.fa-balance-scale-left:before {
+  content: "\f515"; }
+
+.fa-balance-scale-right:before {
+  content: "\f516"; }
+
+.fa-ban:before {
+  content: "\f05e"; }
+
+.fa-band-aid:before {
+  content: "\f462"; }
+
+.fa-bandcamp:before {
+  content: "\f2d5"; }
+
+.fa-barcode:before {
+  content: "\f02a"; }
+
+.fa-bars:before {
+  content: "\f0c9"; }
+
+.fa-baseball-ball:before {
+  content: "\f433"; }
+
+.fa-basketball-ball:before {
+  content: "\f434"; }
+
+.fa-bath:before {
+  content: "\f2cd"; }
+
+.fa-battery-empty:before {
+  content: "\f244"; }
+
+.fa-battery-full:before {
+  content: "\f240"; }
+
+.fa-battery-half:before {
+  content: "\f242"; }
+
+.fa-battery-quarter:before {
+  content: "\f243"; }
+
+.fa-battery-three-quarters:before {
+  content: "\f241"; }
+
+.fa-battle-net:before {
+  content: "\f835"; }
+
+.fa-bed:before {
+  content: "\f236"; }
+
+.fa-beer:before {
+  content: "\f0fc"; }
+
+.fa-behance:before {
+  content: "\f1b4"; }
+
+.fa-behance-square:before {
+  content: "\f1b5"; }
+
+.fa-bell:before {
+  content: "\f0f3"; }
+
+.fa-bell-slash:before {
+  content: "\f1f6"; }
+
+.fa-bezier-curve:before {
+  content: "\f55b"; }
+
+.fa-bible:before {
+  content: "\f647"; }
+
+.fa-bicycle:before {
+  content: "\f206"; }
+
+.fa-biking:before {
+  content: "\f84a"; }
+
+.fa-bimobject:before {
+  content: "\f378"; }
+
+.fa-binoculars:before {
+  content: "\f1e5"; }
+
+.fa-biohazard:before {
+  content: "\f780"; }
+
+.fa-birthday-cake:before {
+  content: "\f1fd"; }
+
+.fa-bitbucket:before {
+  content: "\f171"; }
+
+.fa-bitcoin:before {
+  content: "\f379"; }
+
+.fa-bity:before {
+  content: "\f37a"; }
+
+.fa-black-tie:before {
+  content: "\f27e"; }
+
+.fa-blackberry:before {
+  content: "\f37b"; }
+
+.fa-blender:before {
+  content: "\f517"; }
+
+.fa-blender-phone:before {
+  content: "\f6b6"; }
+
+.fa-blind:before {
+  content: "\f29d"; }
+
+.fa-blog:before {
+  content: "\f781"; }
+
+.fa-blogger:before {
+  content: "\f37c"; }
+
+.fa-blogger-b:before {
+  content: "\f37d"; }
+
+.fa-bluetooth:before {
+  content: "\f293"; }
+
+.fa-bluetooth-b:before {
+  content: "\f294"; }
+
+.fa-bold:before {
+  content: "\f032"; }
+
+.fa-bolt:before {
+  content: "\f0e7"; }
+
+.fa-bomb:before {
+  content: "\f1e2"; }
+
+.fa-bone:before {
+  content: "\f5d7"; }
+
+.fa-bong:before {
+  content: "\f55c"; }
+
+.fa-book:before {
+  content: "\f02d"; }
+
+.fa-book-dead:before {
+  content: "\f6b7"; }
+
+.fa-book-medical:before {
+  content: "\f7e6"; }
+
+.fa-book-open:before {
+  content: "\f518"; }
+
+.fa-book-reader:before {
+  content: "\f5da"; }
+
+.fa-bookmark:before {
+  content: "\f02e"; }
+
+.fa-bootstrap:before {
+  content: "\f836"; }
+
+.fa-border-all:before {
+  content: "\f84c"; }
+
+.fa-border-none:before {
+  content: "\f850"; }
+
+.fa-border-style:before {
+  content: "\f853"; }
+
+.fa-bowling-ball:before {
+  content: "\f436"; }
+
+.fa-box:before {
+  content: "\f466"; }
+
+.fa-box-open:before {
+  content: "\f49e"; }
+
+.fa-box-tissue:before {
+  content: "\e05b"; }
+
+.fa-boxes:before {
+  content: "\f468"; }
+
+.fa-braille:before {
+  content: "\f2a1"; }
+
+.fa-brain:before {
+  content: "\f5dc"; }
+
+.fa-bread-slice:before {
+  content: "\f7ec"; }
+
+.fa-briefcase:before {
+  content: "\f0b1"; }
+
+.fa-briefcase-medical:before {
+  content: "\f469"; }
+
+.fa-broadcast-tower:before {
+  content: "\f519"; }
+
+.fa-broom:before {
+  content: "\f51a"; }
+
+.fa-brush:before {
+  content: "\f55d"; }
+
+.fa-btc:before {
+  content: "\f15a"; }
+
+.fa-buffer:before {
+  content: "\f837"; }
+
+.fa-bug:before {
+  content: "\f188"; }
+
+.fa-building:before {
+  content: "\f1ad"; }
+
+.fa-bullhorn:before {
+  content: "\f0a1"; }
+
+.fa-bullseye:before {
+  content: "\f140"; }
+
+.fa-burn:before {
+  content: "\f46a"; }
+
+.fa-buromobelexperte:before {
+  content: "\f37f"; }
+
+.fa-bus:before {
+  content: "\f207"; }
+
+.fa-bus-alt:before {
+  content: "\f55e"; }
+
+.fa-business-time:before {
+  content: "\f64a"; }
+
+.fa-buy-n-large:before {
+  content: "\f8a6"; }
+
+.fa-buysellads:before {
+  content: "\f20d"; }
+
+.fa-calculator:before {
+  content: "\f1ec"; }
+
+.fa-calendar:before {
+  content: "\f133"; }
+
+.fa-calendar-alt:before {
+  content: "\f073"; }
+
+.fa-calendar-check:before {
+  content: "\f274"; }
+
+.fa-calendar-day:before {
+  content: "\f783"; }
+
+.fa-calendar-minus:before {
+  content: "\f272"; }
+
+.fa-calendar-plus:before {
+  content: "\f271"; }
+
+.fa-calendar-times:before {
+  content: "\f273"; }
+
+.fa-calendar-week:before {
+  content: "\f784"; }
+
+.fa-camera:before {
+  content: "\f030"; }
+
+.fa-camera-retro:before {
+  content: "\f083"; }
+
+.fa-campground:before {
+  content: "\f6bb"; }
+
+.fa-canadian-maple-leaf:before {
+  content: "\f785"; }
+
+.fa-candy-cane:before {
+  content: "\f786"; }
+
+.fa-cannabis:before {
+  content: "\f55f"; }
+
+.fa-capsules:before {
+  content: "\f46b"; }
+
+.fa-car:before {
+  content: "\f1b9"; }
+
+.fa-car-alt:before {
+  content: "\f5de"; }
+
+.fa-car-battery:before {
+  content: "\f5df"; }
+
+.fa-car-crash:before {
+  content: "\f5e1"; }
+
+.fa-car-side:before {
+  content: "\f5e4"; }
+
+.fa-caravan:before {
+  content: "\f8ff"; }
+
+.fa-caret-down:before {
+  content: "\f0d7"; }
+
+.fa-caret-left:before {
+  content: "\f0d9"; }
+
+.fa-caret-right:before {
+  content: "\f0da"; }
+
+.fa-caret-square-down:before {
+  content: "\f150"; }
+
+.fa-caret-square-left:before {
+  content: "\f191"; }
+
+.fa-caret-square-right:before {
+  content: "\f152"; }
+
+.fa-caret-square-up:before {
+  content: "\f151"; }
+
+.fa-caret-up:before {
+  content: "\f0d8"; }
+
+.fa-carrot:before {
+  content: "\f787"; }
+
+.fa-cart-arrow-down:before {
+  content: "\f218"; }
+
+.fa-cart-plus:before {
+  content: "\f217"; }
+
+.fa-cash-register:before {
+  content: "\f788"; }
+
+.fa-cat:before {
+  content: "\f6be"; }
+
+.fa-cc-amazon-pay:before {
+  content: "\f42d"; }
+
+.fa-cc-amex:before {
+  content: "\f1f3"; }
+
+.fa-cc-apple-pay:before {
+  content: "\f416"; }
+
+.fa-cc-diners-club:before {
+  content: "\f24c"; }
+
+.fa-cc-discover:before {
+  content: "\f1f2"; }
+
+.fa-cc-jcb:before {
+  content: "\f24b"; }
+
+.fa-cc-mastercard:before {
+  content: "\f1f1"; }
+
+.fa-cc-paypal:before {
+  content: "\f1f4"; }
+
+.fa-cc-stripe:before {
+  content: "\f1f5"; }
+
+.fa-cc-visa:before {
+  content: "\f1f0"; }
+
+.fa-centercode:before {
+  content: "\f380"; }
+
+.fa-centos:before {
+  content: "\f789"; }
+
+.fa-certificate:before {
+  content: "\f0a3"; }
+
+.fa-chair:before {
+  content: "\f6c0"; }
+
+.fa-chalkboard:before {
+  content: "\f51b"; }
+
+.fa-chalkboard-teacher:before {
+  content: "\f51c"; }
+
+.fa-charging-station:before {
+  content: "\f5e7"; }
+
+.fa-chart-area:before {
+  content: "\f1fe"; }
+
+.fa-chart-bar:before {
+  content: "\f080"; }
+
+.fa-chart-line:before {
+  content: "\f201"; }
+
+.fa-chart-pie:before {
+  content: "\f200"; }
+
+.fa-check:before {
+  content: "\f00c"; }
+
+.fa-check-circle:before {
+  content: "\f058"; }
+
+.fa-check-double:before {
+  content: "\f560"; }
+
+.fa-check-square:before {
+  content: "\f14a"; }
+
+.fa-cheese:before {
+  content: "\f7ef"; }
+
+.fa-chess:before {
+  content: "\f439"; }
+
+.fa-chess-bishop:before {
+  content: "\f43a"; }
+
+.fa-chess-board:before {
+  content: "\f43c"; }
+
+.fa-chess-king:before {
+  content: "\f43f"; }
+
+.fa-chess-knight:before {
+  content: "\f441"; }
+
+.fa-chess-pawn:before {
+  content: "\f443"; }
+
+.fa-chess-queen:before {
+  content: "\f445"; }
+
+.fa-chess-rook:before {
+  content: "\f447"; }
+
+.fa-chevron-circle-down:before {
+  content: "\f13a"; }
+
+.fa-chevron-circle-left:before {
+  content: "\f137"; }
+
+.fa-chevron-circle-right:before {
+  content: "\f138"; }
+
+.fa-chevron-circle-up:before {
+  content: "\f139"; }
+
+.fa-chevron-down:before {
+  content: "\f078"; }
+
+.fa-chevron-left:before {
+  content: "\f053"; }
+
+.fa-chevron-right:before {
+  content: "\f054"; }
+
+.fa-chevron-up:before {
+  content: "\f077"; }
+
+.fa-child:before {
+  content: "\f1ae"; }
+
+.fa-chrome:before {
+  content: "\f268"; }
+
+.fa-chromecast:before {
+  content: "\f838"; }
+
+.fa-church:before {
+  content: "\f51d"; }
+
+.fa-circle:before {
+  content: "\f111"; }
+
+.fa-circle-notch:before {
+  content: "\f1ce"; }
+
+.fa-city:before {
+  content: "\f64f"; }
+
+.fa-clinic-medical:before {
+  content: "\f7f2"; }
+
+.fa-clipboard:before {
+  content: "\f328"; }
+
+.fa-clipboard-check:before {
+  content: "\f46c"; }
+
+.fa-clipboard-list:before {
+  content: "\f46d"; }
+
+.fa-clock:before {
+  content: "\f017"; }
+
+.fa-clone:before {
+  content: "\f24d"; }
+
+.fa-closed-captioning:before {
+  content: "\f20a"; }
+
+.fa-cloud:before {
+  content: "\f0c2"; }
+
+.fa-cloud-download-alt:before {
+  content: "\f381"; }
+
+.fa-cloud-meatball:before {
+  content: "\f73b"; }
+
+.fa-cloud-moon:before {
+  content: "\f6c3"; }
+
+.fa-cloud-moon-rain:before {
+  content: "\f73c"; }
+
+.fa-cloud-rain:before {
+  content: "\f73d"; }
+
+.fa-cloud-showers-heavy:before {
+  content: "\f740"; }
+
+.fa-cloud-sun:before {
+  content: "\f6c4"; }
+
+.fa-cloud-sun-rain:before {
+  content: "\f743"; }
+
+.fa-cloud-upload-alt:before {
+  content: "\f382"; }
+
+.fa-cloudflare:before {
+  content: "\e07d"; }
+
+.fa-cloudscale:before {
+  content: "\f383"; }
+
+.fa-cloudsmith:before {
+  content: "\f384"; }
+
+.fa-cloudversify:before {
+  content: "\f385"; }
+
+.fa-cocktail:before {
+  content: "\f561"; }
+
+.fa-code:before {
+  content: "\f121"; }
+
+.fa-code-branch:before {
+  content: "\f126"; }
+
+.fa-codepen:before {
+  content: "\f1cb"; }
+
+.fa-codiepie:before {
+  content: "\f284"; }
+
+.fa-coffee:before {
+  content: "\f0f4"; }
+
+.fa-cog:before {
+  content: "\f013"; }
+
+.fa-cogs:before {
+  content: "\f085"; }
+
+.fa-coins:before {
+  content: "\f51e"; }
+
+.fa-columns:before {
+  content: "\f0db"; }
+
+.fa-comment:before {
+  content: "\f075"; }
+
+.fa-comment-alt:before {
+  content: "\f27a"; }
+
+.fa-comment-dollar:before {
+  content: "\f651"; }
+
+.fa-comment-dots:before {
+  content: "\f4ad"; }
+
+.fa-comment-medical:before {
+  content: "\f7f5"; }
+
+.fa-comment-slash:before {
+  content: "\f4b3"; }
+
+.fa-comments:before {
+  content: "\f086"; }
+
+.fa-comments-dollar:before {
+  content: "\f653"; }
+
+.fa-compact-disc:before {
+  content: "\f51f"; }
+
+.fa-compass:before {
+  content: "\f14e"; }
+
+.fa-compress:before {
+  content: "\f066"; }
+
+.fa-compress-alt:before {
+  content: "\f422"; }
+
+.fa-compress-arrows-alt:before {
+  content: "\f78c"; }
+
+.fa-concierge-bell:before {
+  content: "\f562"; }
+
+.fa-confluence:before {
+  content: "\f78d"; }
+
+.fa-connectdevelop:before {
+  content: "\f20e"; }
+
+.fa-contao:before {
+  content: "\f26d"; }
+
+.fa-cookie:before {
+  content: "\f563"; }
+
+.fa-cookie-bite:before {
+  content: "\f564"; }
+
+.fa-copy:before {
+  content: "\f0c5"; }
+
+.fa-copyright:before {
+  content: "\f1f9"; }
+
+.fa-cotton-bureau:before {
+  content: "\f89e"; }
+
+.fa-couch:before {
+  content: "\f4b8"; }
+
+.fa-cpanel:before {
+  content: "\f388"; }
+
+.fa-creative-commons:before {
+  content: "\f25e"; }
+
+.fa-creative-commons-by:before {
+  content: "\f4e7"; }
+
+.fa-creative-commons-nc:before {
+  content: "\f4e8"; }
+
+.fa-creative-commons-nc-eu:before {
+  content: "\f4e9"; }
+
+.fa-creative-commons-nc-jp:before {
+  content: "\f4ea"; }
+
+.fa-creative-commons-nd:before {
+  content: "\f4eb"; }
+
+.fa-creative-commons-pd:before {
+  content: "\f4ec"; }
+
+.fa-creative-commons-pd-alt:before {
+  content: "\f4ed"; }
+
+.fa-creative-commons-remix:before {
+  content: "\f4ee"; }
+
+.fa-creative-commons-sa:before {
+  content: "\f4ef"; }
+
+.fa-creative-commons-sampling:before {
+  content: "\f4f0"; }
+
+.fa-creative-commons-sampling-plus:before {
+  content: "\f4f1"; }
+
+.fa-creative-commons-share:before {
+  content: "\f4f2"; }
+
+.fa-creative-commons-zero:before {
+  content: "\f4f3"; }
+
+.fa-credit-card:before {
+  content: "\f09d"; }
+
+.fa-critical-role:before {
+  content: "\f6c9"; }
+
+.fa-crop:before {
+  content: "\f125"; }
+
+.fa-crop-alt:before {
+  content: "\f565"; }
+
+.fa-cross:before {
+  content: "\f654"; }
+
+.fa-crosshairs:before {
+  content: "\f05b"; }
+
+.fa-crow:before {
+  content: "\f520"; }
+
+.fa-crown:before {
+  content: "\f521"; }
+
+.fa-crutch:before {
+  content: "\f7f7"; }
+
+.fa-css3:before {
+  content: "\f13c"; }
+
+.fa-css3-alt:before {
+  content: "\f38b"; }
+
+.fa-cube:before {
+  content: "\f1b2"; }
+
+.fa-cubes:before {
+  content: "\f1b3"; }
+
+.fa-cut:before {
+  content: "\f0c4"; }
+
+.fa-cuttlefish:before {
+  content: "\f38c"; }
+
+.fa-d-and-d:before {
+  content: "\f38d"; }
+
+.fa-d-and-d-beyond:before {
+  content: "\f6ca"; }
+
+.fa-dailymotion:before {
+  content: "\e052"; }
+
+.fa-dashcube:before {
+  content: "\f210"; }
+
+.fa-database:before {
+  content: "\f1c0"; }
+
+.fa-deaf:before {
+  content: "\f2a4"; }
+
+.fa-deezer:before {
+  content: "\e077"; }
+
+.fa-delicious:before {
+  content: "\f1a5"; }
+
+.fa-democrat:before {
+  content: "\f747"; }
+
+.fa-deploydog:before {
+  content: "\f38e"; }
+
+.fa-deskpro:before {
+  content: "\f38f"; }
+
+.fa-desktop:before {
+  content: "\f108"; }
+
+.fa-dev:before {
+  content: "\f6cc"; }
+
+.fa-deviantart:before {
+  content: "\f1bd"; }
+
+.fa-dharmachakra:before {
+  content: "\f655"; }
+
+.fa-dhl:before {
+  content: "\f790"; }
+
+.fa-diagnoses:before {
+  content: "\f470"; }
+
+.fa-diaspora:before {
+  content: "\f791"; }
+
+.fa-dice:before {
+  content: "\f522"; }
+
+.fa-dice-d20:before {
+  content: "\f6cf"; }
+
+.fa-dice-d6:before {
+  content: "\f6d1"; }
+
+.fa-dice-five:before {
+  content: "\f523"; }
+
+.fa-dice-four:before {
+  content: "\f524"; }
+
+.fa-dice-one:before {
+  content: "\f525"; }
+
+.fa-dice-six:before {
+  content: "\f526"; }
+
+.fa-dice-three:before {
+  content: "\f527"; }
+
+.fa-dice-two:before {
+  content: "\f528"; }
+
+.fa-digg:before {
+  content: "\f1a6"; }
+
+.fa-digital-ocean:before {
+  content: "\f391"; }
+
+.fa-digital-tachograph:before {
+  content: "\f566"; }
+
+.fa-directions:before {
+  content: "\f5eb"; }
+
+.fa-discord:before {
+  content: "\f392"; }
+
+.fa-discourse:before {
+  content: "\f393"; }
+
+.fa-disease:before {
+  content: "\f7fa"; }
+
+.fa-divide:before {
+  content: "\f529"; }
+
+.fa-dizzy:before {
+  content: "\f567"; }
+
+.fa-dna:before {
+  content: "\f471"; }
+
+.fa-dochub:before {
+  content: "\f394"; }
+
+.fa-docker:before {
+  content: "\f395"; }
+
+.fa-dog:before {
+  content: "\f6d3"; }
+
+.fa-dollar-sign:before {
+  content: "\f155"; }
+
+.fa-dolly:before {
+  content: "\f472"; }
+
+.fa-dolly-flatbed:before {
+  content: "\f474"; }
+
+.fa-donate:before {
+  content: "\f4b9"; }
+
+.fa-door-closed:before {
+  content: "\f52a"; }
+
+.fa-door-open:before {
+  content: "\f52b"; }
+
+.fa-dot-circle:before {
+  content: "\f192"; }
+
+.fa-dove:before {
+  content: "\f4ba"; }
+
+.fa-download:before {
+  content: "\f019"; }
+
+.fa-draft2digital:before {
+  content: "\f396"; }
+
+.fa-drafting-compass:before {
+  content: "\f568"; }
+
+.fa-dragon:before {
+  content: "\f6d5"; }
+
+.fa-draw-polygon:before {
+  content: "\f5ee"; }
+
+.fa-dribbble:before {
+  content: "\f17d"; }
+
+.fa-dribbble-square:before {
+  content: "\f397"; }
+
+.fa-dropbox:before {
+  content: "\f16b"; }
+
+.fa-drum:before {
+  content: "\f569"; }
+
+.fa-drum-steelpan:before {
+  content: "\f56a"; }
+
+.fa-drumstick-bite:before {
+  content: "\f6d7"; }
+
+.fa-drupal:before {
+  content: "\f1a9"; }
+
+.fa-dumbbell:before {
+  content: "\f44b"; }
+
+.fa-dumpster:before {
+  content: "\f793"; }
+
+.fa-dumpster-fire:before {
+  content: "\f794"; }
+
+.fa-dungeon:before {
+  content: "\f6d9"; }
+
+.fa-dyalog:before {
+  content: "\f399"; }
+
+.fa-earlybirds:before {
+  content: "\f39a"; }
+
+.fa-ebay:before {
+  content: "\f4f4"; }
+
+.fa-edge:before {
+  content: "\f282"; }
+
+.fa-edge-legacy:before {
+  content: "\e078"; }
+
+.fa-edit:before {
+  content: "\f044"; }
+
+.fa-egg:before {
+  content: "\f7fb"; }
+
+.fa-eject:before {
+  content: "\f052"; }
+
+.fa-elementor:before {
+  content: "\f430"; }
+
+.fa-ellipsis-h:before {
+  content: "\f141"; }
+
+.fa-ellipsis-v:before {
+  content: "\f142"; }
+
+.fa-ello:before {
+  content: "\f5f1"; }
+
+.fa-ember:before {
+  content: "\f423"; }
+
+.fa-empire:before {
+  content: "\f1d1"; }
+
+.fa-envelope:before {
+  content: "\f0e0"; }
+
+.fa-envelope-open:before {
+  content: "\f2b6"; }
+
+.fa-envelope-open-text:before {
+  content: "\f658"; }
+
+.fa-envelope-square:before {
+  content: "\f199"; }
+
+.fa-envira:before {
+  content: "\f299"; }
+
+.fa-equals:before {
+  content: "\f52c"; }
+
+.fa-eraser:before {
+  content: "\f12d"; }
+
+.fa-erlang:before {
+  content: "\f39d"; }
+
+.fa-ethereum:before {
+  content: "\f42e"; }
+
+.fa-ethernet:before {
+  content: "\f796"; }
+
+.fa-etsy:before {
+  content: "\f2d7"; }
+
+.fa-euro-sign:before {
+  content: "\f153"; }
+
+.fa-evernote:before {
+  content: "\f839"; }
+
+.fa-exchange-alt:before {
+  content: "\f362"; }
+
+.fa-exclamation:before {
+  content: "\f12a"; }
+
+.fa-exclamation-circle:before {
+  content: "\f06a"; }
+
+.fa-exclamation-triangle:before {
+  content: "\f071"; }
+
+.fa-expand:before {
+  content: "\f065"; }
+
+.fa-expand-alt:before {
+  content: "\f424"; }
+
+.fa-expand-arrows-alt:before {
+  content: "\f31e"; }
+
+.fa-expeditedssl:before {
+  content: "\f23e"; }
+
+.fa-external-link-alt:before {
+  content: "\f35d"; }
+
+.fa-external-link-square-alt:before {
+  content: "\f360"; }
+
+.fa-eye:before {
+  content: "\f06e"; }
+
+.fa-eye-dropper:before {
+  content: "\f1fb"; }
+
+.fa-eye-slash:before {
+  content: "\f070"; }
+
+.fa-facebook:before {
+  content: "\f09a"; }
+
+.fa-facebook-f:before {
+  content: "\f39e"; }
+
+.fa-facebook-messenger:before {
+  content: "\f39f"; }
+
+.fa-facebook-square:before {
+  content: "\f082"; }
+
+.fa-fan:before {
+  content: "\f863"; }
+
+.fa-fantasy-flight-games:before {
+  content: "\f6dc"; }
+
+.fa-fast-backward:before {
+  content: "\f049"; }
+
+.fa-fast-forward:before {
+  content: "\f050"; }
+
+.fa-faucet:before {
+  content: "\e005"; }
+
+.fa-fax:before {
+  content: "\f1ac"; }
+
+.fa-feather:before {
+  content: "\f52d"; }
+
+.fa-feather-alt:before {
+  content: "\f56b"; }
+
+.fa-fedex:before {
+  content: "\f797"; }
+
+.fa-fedora:before {
+  content: "\f798"; }
+
+.fa-female:before {
+  content: "\f182"; }
+
+.fa-fighter-jet:before {
+  content: "\f0fb"; }
+
+.fa-figma:before {
+  content: "\f799"; }
+
+.fa-file:before {
+  content: "\f15b"; }
+
+.fa-file-alt:before {
+  content: "\f15c"; }
+
+.fa-file-archive:before {
+  content: "\f1c6"; }
+
+.fa-file-audio:before {
+  content: "\f1c7"; }
+
+.fa-file-code:before {
+  content: "\f1c9"; }
+
+.fa-file-contract:before {
+  content: "\f56c"; }
+
+.fa-file-csv:before {
+  content: "\f6dd"; }
+
+.fa-file-download:before {
+  content: "\f56d"; }
+
+.fa-file-excel:before {
+  content: "\f1c3"; }
+
+.fa-file-export:before {
+  content: "\f56e"; }
+
+.fa-file-image:before {
+  content: "\f1c5"; }
+
+.fa-file-import:before {
+  content: "\f56f"; }
+
+.fa-file-invoice:before {
+  content: "\f570"; }
+
+.fa-file-invoice-dollar:before {
+  content: "\f571"; }
+
+.fa-file-medical:before {
+  content: "\f477"; }
+
+.fa-file-medical-alt:before {
+  content: "\f478"; }
+
+.fa-file-pdf:before {
+  content: "\f1c1"; }
+
+.fa-file-powerpoint:before {
+  content: "\f1c4"; }
+
+.fa-file-prescription:before {
+  content: "\f572"; }
+
+.fa-file-signature:before {
+  content: "\f573"; }
+
+.fa-file-upload:before {
+  content: "\f574"; }
+
+.fa-file-video:before {
+  content: "\f1c8"; }
+
+.fa-file-word:before {
+  content: "\f1c2"; }
+
+.fa-fill:before {
+  content: "\f575"; }
+
+.fa-fill-drip:before {
+  content: "\f576"; }
+
+.fa-film:before {
+  content: "\f008"; }
+
+.fa-filter:before {
+  content: "\f0b0"; }
+
+.fa-fingerprint:before {
+  content: "\f577"; }
+
+.fa-fire:before {
+  content: "\f06d"; }
+
+.fa-fire-alt:before {
+  content: "\f7e4"; }
+
+.fa-fire-extinguisher:before {
+  content: "\f134"; }
+
+.fa-firefox:before {
+  content: "\f269"; }
+
+.fa-firefox-browser:before {
+  content: "\e007"; }
+
+.fa-first-aid:before {
+  content: "\f479"; }
+
+.fa-first-order:before {
+  content: "\f2b0"; }
+
+.fa-first-order-alt:before {
+  content: "\f50a"; }
+
+.fa-firstdraft:before {
+  content: "\f3a1"; }
+
+.fa-fish:before {
+  content: "\f578"; }
+
+.fa-fist-raised:before {
+  content: "\f6de"; }
+
+.fa-flag:before {
+  content: "\f024"; }
+
+.fa-flag-checkered:before {
+  content: "\f11e"; }
+
+.fa-flag-usa:before {
+  content: "\f74d"; }
+
+.fa-flask:before {
+  content: "\f0c3"; }
+
+.fa-flickr:before {
+  content: "\f16e"; }
+
+.fa-flipboard:before {
+  content: "\f44d"; }
+
+.fa-flushed:before {
+  content: "\f579"; }
+
+.fa-fly:before {
+  content: "\f417"; }
+
+.fa-folder:before {
+  content: "\f07b"; }
+
+.fa-folder-minus:before {
+  content: "\f65d"; }
+
+.fa-folder-open:before {
+  content: "\f07c"; }
+
+.fa-folder-plus:before {
+  content: "\f65e"; }
+
+.fa-font:before {
+  content: "\f031"; }
+
+.fa-font-awesome:before {
+  content: "\f2b4"; }
+
+.fa-font-awesome-alt:before {
+  content: "\f35c"; }
+
+.fa-font-awesome-flag:before {
+  content: "\f425"; }
+
+.fa-font-awesome-logo-full:before {
+  content: "\f4e6"; }
+
+.fa-fonticons:before {
+  content: "\f280"; }
+
+.fa-fonticons-fi:before {
+  content: "\f3a2"; }
+
+.fa-football-ball:before {
+  content: "\f44e"; }
+
+.fa-fort-awesome:before {
+  content: "\f286"; }
+
+.fa-fort-awesome-alt:before {
+  content: "\f3a3"; }
+
+.fa-forumbee:before {
+  content: "\f211"; }
+
+.fa-forward:before {
+  content: "\f04e"; }
+
+.fa-foursquare:before {
+  content: "\f180"; }
+
+.fa-free-code-camp:before {
+  content: "\f2c5"; }
+
+.fa-freebsd:before {
+  content: "\f3a4"; }
+
+.fa-frog:before {
+  content: "\f52e"; }
+
+.fa-frown:before {
+  content: "\f119"; }
+
+.fa-frown-open:before {
+  content: "\f57a"; }
+
+.fa-fulcrum:before {
+  content: "\f50b"; }
+
+.fa-funnel-dollar:before {
+  content: "\f662"; }
+
+.fa-futbol:before {
+  content: "\f1e3"; }
+
+.fa-galactic-republic:before {
+  content: "\f50c"; }
+
+.fa-galactic-senate:before {
+  content: "\f50d"; }
+
+.fa-gamepad:before {
+  content: "\f11b"; }
+
+.fa-gas-pump:before {
+  content: "\f52f"; }
+
+.fa-gavel:before {
+  content: "\f0e3"; }
+
+.fa-gem:before {
+  content: "\f3a5"; }
+
+.fa-genderless:before {
+  content: "\f22d"; }
+
+.fa-get-pocket:before {
+  content: "\f265"; }
+
+.fa-gg:before {
+  content: "\f260"; }
+
+.fa-gg-circle:before {
+  content: "\f261"; }
+
+.fa-ghost:before {
+  content: "\f6e2"; }
+
+.fa-gift:before {
+  content: "\f06b"; }
+
+.fa-gifts:before {
+  content: "\f79c"; }
+
+.fa-git:before {
+  content: "\f1d3"; }
+
+.fa-git-alt:before {
+  content: "\f841"; }
+
+.fa-git-square:before {
+  content: "\f1d2"; }
+
+.fa-github:before {
+  content: "\f09b"; }
+
+.fa-github-alt:before {
+  content: "\f113"; }
+
+.fa-github-square:before {
+  content: "\f092"; }
+
+.fa-gitkraken:before {
+  content: "\f3a6"; }
+
+.fa-gitlab:before {
+  content: "\f296"; }
+
+.fa-gitter:before {
+  content: "\f426"; }
+
+.fa-glass-cheers:before {
+  content: "\f79f"; }
+
+.fa-glass-martini:before {
+  content: "\f000"; }
+
+.fa-glass-martini-alt:before {
+  content: "\f57b"; }
+
+.fa-glass-whiskey:before {
+  content: "\f7a0"; }
+
+.fa-glasses:before {
+  content: "\f530"; }
+
+.fa-glide:before {
+  content: "\f2a5"; }
+
+.fa-glide-g:before {
+  content: "\f2a6"; }
+
+.fa-globe:before {
+  content: "\f0ac"; }
+
+.fa-globe-africa:before {
+  content: "\f57c"; }
+
+.fa-globe-americas:before {
+  content: "\f57d"; }
+
+.fa-globe-asia:before {
+  content: "\f57e"; }
+
+.fa-globe-europe:before {
+  content: "\f7a2"; }
+
+.fa-gofore:before {
+  content: "\f3a7"; }
+
+.fa-golf-ball:before {
+  content: "\f450"; }
+
+.fa-goodreads:before {
+  content: "\f3a8"; }
+
+.fa-goodreads-g:before {
+  content: "\f3a9"; }
+
+.fa-google:before {
+  content: "\f1a0"; }
+
+.fa-google-drive:before {
+  content: "\f3aa"; }
+
+.fa-google-pay:before {
+  content: "\e079"; }
+
+.fa-google-play:before {
+  content: "\f3ab"; }
+
+.fa-google-plus:before {
+  content: "\f2b3"; }
+
+.fa-google-plus-g:before {
+  content: "\f0d5"; }
+
+.fa-google-plus-square:before {
+  content: "\f0d4"; }
+
+.fa-google-wallet:before {
+  content: "\f1ee"; }
+
+.fa-gopuram:before {
+  content: "\f664"; }
+
+.fa-graduation-cap:before {
+  content: "\f19d"; }
+
+.fa-gratipay:before {
+  content: "\f184"; }
+
+.fa-grav:before {
+  content: "\f2d6"; }
+
+.fa-greater-than:before {
+  content: "\f531"; }
+
+.fa-greater-than-equal:before {
+  content: "\f532"; }
+
+.fa-grimace:before {
+  content: "\f57f"; }
+
+.fa-grin:before {
+  content: "\f580"; }
+
+.fa-grin-alt:before {
+  content: "\f581"; }
+
+.fa-grin-beam:before {
+  content: "\f582"; }
+
+.fa-grin-beam-sweat:before {
+  content: "\f583"; }
+
+.fa-grin-hearts:before {
+  content: "\f584"; }
+
+.fa-grin-squint:before {
+  content: "\f585"; }
+
+.fa-grin-squint-tears:before {
+  content: "\f586"; }
+
+.fa-grin-stars:before {
+  content: "\f587"; }
+
+.fa-grin-tears:before {
+  content: "\f588"; }
+
+.fa-grin-tongue:before {
+  content: "\f589"; }
+
+.fa-grin-tongue-squint:before {
+  content: "\f58a"; }
+
+.fa-grin-tongue-wink:before {
+  content: "\f58b"; }
+
+.fa-grin-wink:before {
+  content: "\f58c"; }
+
+.fa-grip-horizontal:before {
+  content: "\f58d"; }
+
+.fa-grip-lines:before {
+  content: "\f7a4"; }
+
+.fa-grip-lines-vertical:before {
+  content: "\f7a5"; }
+
+.fa-grip-vertical:before {
+  content: "\f58e"; }
+
+.fa-gripfire:before {
+  content: "\f3ac"; }
+
+.fa-grunt:before {
+  content: "\f3ad"; }
+
+.fa-guilded:before {
+  content: "\e07e"; }
+
+.fa-guitar:before {
+  content: "\f7a6"; }
+
+.fa-gulp:before {
+  content: "\f3ae"; }
+
+.fa-h-square:before {
+  content: "\f0fd"; }
+
+.fa-hacker-news:before {
+  content: "\f1d4"; }
+
+.fa-hacker-news-square:before {
+  content: "\f3af"; }
+
+.fa-hackerrank:before {
+  content: "\f5f7"; }
+
+.fa-hamburger:before {
+  content: "\f805"; }
+
+.fa-hammer:before {
+  content: "\f6e3"; }
+
+.fa-hamsa:before {
+  content: "\f665"; }
+
+.fa-hand-holding:before {
+  content: "\f4bd"; }
+
+.fa-hand-holding-heart:before {
+  content: "\f4be"; }
+
+.fa-hand-holding-medical:before {
+  content: "\e05c"; }
+
+.fa-hand-holding-usd:before {
+  content: "\f4c0"; }
+
+.fa-hand-holding-water:before {
+  content: "\f4c1"; }
+
+.fa-hand-lizard:before {
+  content: "\f258"; }
+
+.fa-hand-middle-finger:before {
+  content: "\f806"; }
+
+.fa-hand-paper:before {
+  content: "\f256"; }
+
+.fa-hand-peace:before {
+  content: "\f25b"; }
+
+.fa-hand-point-down:before {
+  content: "\f0a7"; }
+
+.fa-hand-point-left:before {
+  content: "\f0a5"; }
+
+.fa-hand-point-right:before {
+  content: "\f0a4"; }
+
+.fa-hand-point-up:before {
+  content: "\f0a6"; }
+
+.fa-hand-pointer:before {
+  content: "\f25a"; }
+
+.fa-hand-rock:before {
+  content: "\f255"; }
+
+.fa-hand-scissors:before {
+  content: "\f257"; }
+
+.fa-hand-sparkles:before {
+  content: "\e05d"; }
+
+.fa-hand-spock:before {
+  content: "\f259"; }
+
+.fa-hands:before {
+  content: "\f4c2"; }
+
+.fa-hands-helping:before {
+  content: "\f4c4"; }
+
+.fa-hands-wash:before {
+  content: "\e05e"; }
+
+.fa-handshake:before {
+  content: "\f2b5"; }
+
+.fa-handshake-alt-slash:before {
+  content: "\e05f"; }
+
+.fa-handshake-slash:before {
+  content: "\e060"; }
+
+.fa-hanukiah:before {
+  content: "\f6e6"; }
+
+.fa-hard-hat:before {
+  content: "\f807"; }
+
+.fa-hashtag:before {
+  content: "\f292"; }
+
+.fa-hat-cowboy:before {
+  content: "\f8c0"; }
+
+.fa-hat-cowboy-side:before {
+  content: "\f8c1"; }
+
+.fa-hat-wizard:before {
+  content: "\f6e8"; }
+
+.fa-hdd:before {
+  content: "\f0a0"; }
+
+.fa-head-side-cough:before {
+  content: "\e061"; }
+
+.fa-head-side-cough-slash:before {
+  content: "\e062"; }
+
+.fa-head-side-mask:before {
+  content: "\e063"; }
+
+.fa-head-side-virus:before {
+  content: "\e064"; }
+
+.fa-heading:before {
+  content: "\f1dc"; }
+
+.fa-headphones:before {
+  content: "\f025"; }
+
+.fa-headphones-alt:before {
+  content: "\f58f"; }
+
+.fa-headset:before {
+  content: "\f590"; }
+
+.fa-heart:before {
+  content: "\f004"; }
+
+.fa-heart-broken:before {
+  content: "\f7a9"; }
+
+.fa-heartbeat:before {
+  content: "\f21e"; }
+
+.fa-helicopter:before {
+  content: "\f533"; }
+
+.fa-highlighter:before {
+  content: "\f591"; }
+
+.fa-hiking:before {
+  content: "\f6ec"; }
+
+.fa-hippo:before {
+  content: "\f6ed"; }
+
+.fa-hips:before {
+  content: "\f452"; }
+
+.fa-hire-a-helper:before {
+  content: "\f3b0"; }
+
+.fa-history:before {
+  content: "\f1da"; }
+
+.fa-hive:before {
+  content: "\e07f"; }
+
+.fa-hockey-puck:before {
+  content: "\f453"; }
+
+.fa-holly-berry:before {
+  content: "\f7aa"; }
+
+.fa-home:before {
+  content: "\f015"; }
+
+.fa-hooli:before {
+  content: "\f427"; }
+
+.fa-hornbill:before {
+  content: "\f592"; }
+
+.fa-horse:before {
+  content: "\f6f0"; }
+
+.fa-horse-head:before {
+  content: "\f7ab"; }
+
+.fa-hospital:before {
+  content: "\f0f8"; }
+
+.fa-hospital-alt:before {
+  content: "\f47d"; }
+
+.fa-hospital-symbol:before {
+  content: "\f47e"; }
+
+.fa-hospital-user:before {
+  content: "\f80d"; }
+
+.fa-hot-tub:before {
+  content: "\f593"; }
+
+.fa-hotdog:before {
+  content: "\f80f"; }
+
+.fa-hotel:before {
+  content: "\f594"; }
+
+.fa-hotjar:before {
+  content: "\f3b1"; }
+
+.fa-hourglass:before {
+  content: "\f254"; }
+
+.fa-hourglass-end:before {
+  content: "\f253"; }
+
+.fa-hourglass-half:before {
+  content: "\f252"; }
+
+.fa-hourglass-start:before {
+  content: "\f251"; }
+
+.fa-house-damage:before {
+  content: "\f6f1"; }
+
+.fa-house-user:before {
+  content: "\e065"; }
+
+.fa-houzz:before {
+  content: "\f27c"; }
+
+.fa-hryvnia:before {
+  content: "\f6f2"; }
+
+.fa-html5:before {
+  content: "\f13b"; }
+
+.fa-hubspot:before {
+  content: "\f3b2"; }
+
+.fa-i-cursor:before {
+  content: "\f246"; }
+
+.fa-ice-cream:before {
+  content: "\f810"; }
+
+.fa-icicles:before {
+  content: "\f7ad"; }
+
+.fa-icons:before {
+  content: "\f86d"; }
+
+.fa-id-badge:before {
+  content: "\f2c1"; }
+
+.fa-id-card:before {
+  content: "\f2c2"; }
+
+.fa-id-card-alt:before {
+  content: "\f47f"; }
+
+.fa-ideal:before {
+  content: "\e013"; }
+
+.fa-igloo:before {
+  content: "\f7ae"; }
+
+.fa-image:before {
+  content: "\f03e"; }
+
+.fa-images:before {
+  content: "\f302"; }
+
+.fa-imdb:before {
+  content: "\f2d8"; }
+
+.fa-inbox:before {
+  content: "\f01c"; }
+
+.fa-indent:before {
+  content: "\f03c"; }
+
+.fa-industry:before {
+  content: "\f275"; }
+
+.fa-infinity:before {
+  content: "\f534"; }
+
+.fa-info:before {
+  content: "\f129"; }
+
+.fa-info-circle:before {
+  content: "\f05a"; }
+
+.fa-innosoft:before {
+  content: "\e080"; }
+
+.fa-instagram:before {
+  content: "\f16d"; }
+
+.fa-instagram-square:before {
+  content: "\e055"; }
+
+.fa-instalod:before {
+  content: "\e081"; }
+
+.fa-intercom:before {
+  content: "\f7af"; }
+
+.fa-internet-explorer:before {
+  content: "\f26b"; }
+
+.fa-invision:before {
+  content: "\f7b0"; }
+
+.fa-ioxhost:before {
+  content: "\f208"; }
+
+.fa-italic:before {
+  content: "\f033"; }
+
+.fa-itch-io:before {
+  content: "\f83a"; }
+
+.fa-itunes:before {
+  content: "\f3b4"; }
+
+.fa-itunes-note:before {
+  content: "\f3b5"; }
+
+.fa-java:before {
+  content: "\f4e4"; }
+
+.fa-jedi:before {
+  content: "\f669"; }
+
+.fa-jedi-order:before {
+  content: "\f50e"; }
+
+.fa-jenkins:before {
+  content: "\f3b6"; }
+
+.fa-jira:before {
+  content: "\f7b1"; }
+
+.fa-joget:before {
+  content: "\f3b7"; }
+
+.fa-joint:before {
+  content: "\f595"; }
+
+.fa-joomla:before {
+  content: "\f1aa"; }
+
+.fa-journal-whills:before {
+  content: "\f66a"; }
+
+.fa-js:before {
+  content: "\f3b8"; }
+
+.fa-js-square:before {
+  content: "\f3b9"; }
+
+.fa-jsfiddle:before {
+  content: "\f1cc"; }
+
+.fa-kaaba:before {
+  content: "\f66b"; }
+
+.fa-kaggle:before {
+  content: "\f5fa"; }
+
+.fa-key:before {
+  content: "\f084"; }
+
+.fa-keybase:before {
+  content: "\f4f5"; }
+
+.fa-keyboard:before {
+  content: "\f11c"; }
+
+.fa-keycdn:before {
+  content: "\f3ba"; }
+
+.fa-khanda:before {
+  content: "\f66d"; }
+
+.fa-kickstarter:before {
+  content: "\f3bb"; }
+
+.fa-kickstarter-k:before {
+  content: "\f3bc"; }
+
+.fa-kiss:before {
+  content: "\f596"; }
+
+.fa-kiss-beam:before {
+  content: "\f597"; }
+
+.fa-kiss-wink-heart:before {
+  content: "\f598"; }
+
+.fa-kiwi-bird:before {
+  content: "\f535"; }
+
+.fa-korvue:before {
+  content: "\f42f"; }
+
+.fa-landmark:before {
+  content: "\f66f"; }
+
+.fa-language:before {
+  content: "\f1ab"; }
+
+.fa-laptop:before {
+  content: "\f109"; }
+
+.fa-laptop-code:before {
+  content: "\f5fc"; }
+
+.fa-laptop-house:before {
+  content: "\e066"; }
+
+.fa-laptop-medical:before {
+  content: "\f812"; }
+
+.fa-laravel:before {
+  content: "\f3bd"; }
+
+.fa-lastfm:before {
+  content: "\f202"; }
+
+.fa-lastfm-square:before {
+  content: "\f203"; }
+
+.fa-laugh:before {
+  content: "\f599"; }
+
+.fa-laugh-beam:before {
+  content: "\f59a"; }
+
+.fa-laugh-squint:before {
+  content: "\f59b"; }
+
+.fa-laugh-wink:before {
+  content: "\f59c"; }
+
+.fa-layer-group:before {
+  content: "\f5fd"; }
+
+.fa-leaf:before {
+  content: "\f06c"; }
+
+.fa-leanpub:before {
+  content: "\f212"; }
+
+.fa-lemon:before {
+  content: "\f094"; }
+
+.fa-less:before {
+  content: "\f41d"; }
+
+.fa-less-than:before {
+  content: "\f536"; }
+
+.fa-less-than-equal:before {
+  content: "\f537"; }
+
+.fa-level-down-alt:before {
+  content: "\f3be"; }
+
+.fa-level-up-alt:before {
+  content: "\f3bf"; }
+
+.fa-life-ring:before {
+  content: "\f1cd"; }
+
+.fa-lightbulb:before {
+  content: "\f0eb"; }
+
+.fa-line:before {
+  content: "\f3c0"; }
+
+.fa-link:before {
+  content: "\f0c1"; }
+
+.fa-linkedin:before {
+  content: "\f08c"; }
+
+.fa-linkedin-in:before {
+  content: "\f0e1"; }
+
+.fa-linode:before {
+  content: "\f2b8"; }
+
+.fa-linux:before {
+  content: "\f17c"; }
+
+.fa-lira-sign:before {
+  content: "\f195"; }
+
+.fa-list:before {
+  content: "\f03a"; }
+
+.fa-list-alt:before {
+  content: "\f022"; }
+
+.fa-list-ol:before {
+  content: "\f0cb"; }
+
+.fa-list-ul:before {
+  content: "\f0ca"; }
+
+.fa-location-arrow:before {
+  content: "\f124"; }
+
+.fa-lock:before {
+  content: "\f023"; }
+
+.fa-lock-open:before {
+  content: "\f3c1"; }
+
+.fa-long-arrow-alt-down:before {
+  content: "\f309"; }
+
+.fa-long-arrow-alt-left:before {
+  content: "\f30a"; }
+
+.fa-long-arrow-alt-right:before {
+  content: "\f30b"; }
+
+.fa-long-arrow-alt-up:before {
+  content: "\f30c"; }
+
+.fa-low-vision:before {
+  content: "\f2a8"; }
+
+.fa-luggage-cart:before {
+  content: "\f59d"; }
+
+.fa-lungs:before {
+  content: "\f604"; }
+
+.fa-lungs-virus:before {
+  content: "\e067"; }
+
+.fa-lyft:before {
+  content: "\f3c3"; }
+
+.fa-magento:before {
+  content: "\f3c4"; }
+
+.fa-magic:before {
+  content: "\f0d0"; }
+
+.fa-magnet:before {
+  content: "\f076"; }
+
+.fa-mail-bulk:before {
+  content: "\f674"; }
+
+.fa-mailchimp:before {
+  content: "\f59e"; }
+
+.fa-male:before {
+  content: "\f183"; }
+
+.fa-mandalorian:before {
+  content: "\f50f"; }
+
+.fa-map:before {
+  content: "\f279"; }
+
+.fa-map-marked:before {
+  content: "\f59f"; }
+
+.fa-map-marked-alt:before {
+  content: "\f5a0"; }
+
+.fa-map-marker:before {
+  content: "\f041"; }
+
+.fa-map-marker-alt:before {
+  content: "\f3c5"; }
+
+.fa-map-pin:before {
+  content: "\f276"; }
+
+.fa-map-signs:before {
+  content: "\f277"; }
+
+.fa-markdown:before {
+  content: "\f60f"; }
+
+.fa-marker:before {
+  content: "\f5a1"; }
+
+.fa-mars:before {
+  content: "\f222"; }
+
+.fa-mars-double:before {
+  content: "\f227"; }
+
+.fa-mars-stroke:before {
+  content: "\f229"; }
+
+.fa-mars-stroke-h:before {
+  content: "\f22b"; }
+
+.fa-mars-stroke-v:before {
+  content: "\f22a"; }
+
+.fa-mask:before {
+  content: "\f6fa"; }
+
+.fa-mastodon:before {
+  content: "\f4f6"; }
+
+.fa-maxcdn:before {
+  content: "\f136"; }
+
+.fa-mdb:before {
+  content: "\f8ca"; }
+
+.fa-medal:before {
+  content: "\f5a2"; }
+
+.fa-medapps:before {
+  content: "\f3c6"; }
+
+.fa-medium:before {
+  content: "\f23a"; }
+
+.fa-medium-m:before {
+  content: "\f3c7"; }
+
+.fa-medkit:before {
+  content: "\f0fa"; }
+
+.fa-medrt:before {
+  content: "\f3c8"; }
+
+.fa-meetup:before {
+  content: "\f2e0"; }
+
+.fa-megaport:before {
+  content: "\f5a3"; }
+
+.fa-meh:before {
+  content: "\f11a"; }
+
+.fa-meh-blank:before {
+  content: "\f5a4"; }
+
+.fa-meh-rolling-eyes:before {
+  content: "\f5a5"; }
+
+.fa-memory:before {
+  content: "\f538"; }
+
+.fa-mendeley:before {
+  content: "\f7b3"; }
+
+.fa-menorah:before {
+  content: "\f676"; }
+
+.fa-mercury:before {
+  content: "\f223"; }
+
+.fa-meteor:before {
+  content: "\f753"; }
+
+.fa-microblog:before {
+  content: "\e01a"; }
+
+.fa-microchip:before {
+  content: "\f2db"; }
+
+.fa-microphone:before {
+  content: "\f130"; }
+
+.fa-microphone-alt:before {
+  content: "\f3c9"; }
+
+.fa-microphone-alt-slash:before {
+  content: "\f539"; }
+
+.fa-microphone-slash:before {
+  content: "\f131"; }
+
+.fa-microscope:before {
+  content: "\f610"; }
+
+.fa-microsoft:before {
+  content: "\f3ca"; }
+
+.fa-minus:before {
+  content: "\f068"; }
+
+.fa-minus-circle:before {
+  content: "\f056"; }
+
+.fa-minus-square:before {
+  content: "\f146"; }
+
+.fa-mitten:before {
+  content: "\f7b5"; }
+
+.fa-mix:before {
+  content: "\f3cb"; }
+
+.fa-mixcloud:before {
+  content: "\f289"; }
+
+.fa-mixer:before {
+  content: "\e056"; }
+
+.fa-mizuni:before {
+  content: "\f3cc"; }
+
+.fa-mobile:before {
+  content: "\f10b"; }
+
+.fa-mobile-alt:before {
+  content: "\f3cd"; }
+
+.fa-modx:before {
+  content: "\f285"; }
+
+.fa-monero:before {
+  content: "\f3d0"; }
+
+.fa-money-bill:before {
+  content: "\f0d6"; }
+
+.fa-money-bill-alt:before {
+  content: "\f3d1"; }
+
+.fa-money-bill-wave:before {
+  content: "\f53a"; }
+
+.fa-money-bill-wave-alt:before {
+  content: "\f53b"; }
+
+.fa-money-check:before {
+  content: "\f53c"; }
+
+.fa-money-check-alt:before {
+  content: "\f53d"; }
+
+.fa-monument:before {
+  content: "\f5a6"; }
+
+.fa-moon:before {
+  content: "\f186"; }
+
+.fa-mortar-pestle:before {
+  content: "\f5a7"; }
+
+.fa-mosque:before {
+  content: "\f678"; }
+
+.fa-motorcycle:before {
+  content: "\f21c"; }
+
+.fa-mountain:before {
+  content: "\f6fc"; }
+
+.fa-mouse:before {
+  content: "\f8cc"; }
+
+.fa-mouse-pointer:before {
+  content: "\f245"; }
+
+.fa-mug-hot:before {
+  content: "\f7b6"; }
+
+.fa-music:before {
+  content: "\f001"; }
+
+.fa-napster:before {
+  content: "\f3d2"; }
+
+.fa-neos:before {
+  content: "\f612"; }
+
+.fa-network-wired:before {
+  content: "\f6ff"; }
+
+.fa-neuter:before {
+  content: "\f22c"; }
+
+.fa-newspaper:before {
+  content: "\f1ea"; }
+
+.fa-nimblr:before {
+  content: "\f5a8"; }
+
+.fa-node:before {
+  content: "\f419"; }
+
+.fa-node-js:before {
+  content: "\f3d3"; }
+
+.fa-not-equal:before {
+  content: "\f53e"; }
+
+.fa-notes-medical:before {
+  content: "\f481"; }
+
+.fa-npm:before {
+  content: "\f3d4"; }
+
+.fa-ns8:before {
+  content: "\f3d5"; }
+
+.fa-nutritionix:before {
+  content: "\f3d6"; }
+
+.fa-object-group:before {
+  content: "\f247"; }
+
+.fa-object-ungroup:before {
+  content: "\f248"; }
+
+.fa-octopus-deploy:before {
+  content: "\e082"; }
+
+.fa-odnoklassniki:before {
+  content: "\f263"; }
+
+.fa-odnoklassniki-square:before {
+  content: "\f264"; }
+
+.fa-oil-can:before {
+  content: "\f613"; }
+
+.fa-old-republic:before {
+  content: "\f510"; }
+
+.fa-om:before {
+  content: "\f679"; }
+
+.fa-opencart:before {
+  content: "\f23d"; }
+
+.fa-openid:before {
+  content: "\f19b"; }
+
+.fa-opera:before {
+  content: "\f26a"; }
+
+.fa-optin-monster:before {
+  content: "\f23c"; }
+
+.fa-orcid:before {
+  content: "\f8d2"; }
+
+.fa-osi:before {
+  content: "\f41a"; }
+
+.fa-otter:before {
+  content: "\f700"; }
+
+.fa-outdent:before {
+  content: "\f03b"; }
+
+.fa-page4:before {
+  content: "\f3d7"; }
+
+.fa-pagelines:before {
+  content: "\f18c"; }
+
+.fa-pager:before {
+  content: "\f815"; }
+
+.fa-paint-brush:before {
+  content: "\f1fc"; }
+
+.fa-paint-roller:before {
+  content: "\f5aa"; }
+
+.fa-palette:before {
+  content: "\f53f"; }
+
+.fa-palfed:before {
+  content: "\f3d8"; }
+
+.fa-pallet:before {
+  content: "\f482"; }
+
+.fa-paper-plane:before {
+  content: "\f1d8"; }
+
+.fa-paperclip:before {
+  content: "\f0c6"; }
+
+.fa-parachute-box:before {
+  content: "\f4cd"; }
+
+.fa-paragraph:before {
+  content: "\f1dd"; }
+
+.fa-parking:before {
+  content: "\f540"; }
+
+.fa-passport:before {
+  content: "\f5ab"; }
+
+.fa-pastafarianism:before {
+  content: "\f67b"; }
+
+.fa-paste:before {
+  content: "\f0ea"; }
+
+.fa-patreon:before {
+  content: "\f3d9"; }
+
+.fa-pause:before {
+  content: "\f04c"; }
+
+.fa-pause-circle:before {
+  content: "\f28b"; }
+
+.fa-paw:before {
+  content: "\f1b0"; }
+
+.fa-paypal:before {
+  content: "\f1ed"; }
+
+.fa-peace:before {
+  content: "\f67c"; }
+
+.fa-pen:before {
+  content: "\f304"; }
+
+.fa-pen-alt:before {
+  content: "\f305"; }
+
+.fa-pen-fancy:before {
+  content: "\f5ac"; }
+
+.fa-pen-nib:before {
+  content: "\f5ad"; }
+
+.fa-pen-square:before {
+  content: "\f14b"; }
+
+.fa-pencil-alt:before {
+  content: "\f303"; }
+
+.fa-pencil-ruler:before {
+  content: "\f5ae"; }
+
+.fa-penny-arcade:before {
+  content: "\f704"; }
+
+.fa-people-arrows:before {
+  content: "\e068"; }
+
+.fa-people-carry:before {
+  content: "\f4ce"; }
+
+.fa-pepper-hot:before {
+  content: "\f816"; }
+
+.fa-perbyte:before {
+  content: "\e083"; }
+
+.fa-percent:before {
+  content: "\f295"; }
+
+.fa-percentage:before {
+  content: "\f541"; }
+
+.fa-periscope:before {
+  content: "\f3da"; }
+
+.fa-person-booth:before {
+  content: "\f756"; }
+
+.fa-phabricator:before {
+  content: "\f3db"; }
+
+.fa-phoenix-framework:before {
+  content: "\f3dc"; }
+
+.fa-phoenix-squadron:before {
+  content: "\f511"; }
+
+.fa-phone:before {
+  content: "\f095"; }
+
+.fa-phone-alt:before {
+  content: "\f879"; }
+
+.fa-phone-slash:before {
+  content: "\f3dd"; }
+
+.fa-phone-square:before {
+  content: "\f098"; }
+
+.fa-phone-square-alt:before {
+  content: "\f87b"; }
+
+.fa-phone-volume:before {
+  content: "\f2a0"; }
+
+.fa-photo-video:before {
+  content: "\f87c"; }
+
+.fa-php:before {
+  content: "\f457"; }
+
+.fa-pied-piper:before {
+  content: "\f2ae"; }
+
+.fa-pied-piper-alt:before {
+  content: "\f1a8"; }
+
+.fa-pied-piper-hat:before {
+  content: "\f4e5"; }
+
+.fa-pied-piper-pp:before {
+  content: "\f1a7"; }
+
+.fa-pied-piper-square:before {
+  content: "\e01e"; }
+
+.fa-piggy-bank:before {
+  content: "\f4d3"; }
+
+.fa-pills:before {
+  content: "\f484"; }
+
+.fa-pinterest:before {
+  content: "\f0d2"; }
+
+.fa-pinterest-p:before {
+  content: "\f231"; }
+
+.fa-pinterest-square:before {
+  content: "\f0d3"; }
+
+.fa-pizza-slice:before {
+  content: "\f818"; }
+
+.fa-place-of-worship:before {
+  content: "\f67f"; }
+
+.fa-plane:before {
+  content: "\f072"; }
+
+.fa-plane-arrival:before {
+  content: "\f5af"; }
+
+.fa-plane-departure:before {
+  content: "\f5b0"; }
+
+.fa-plane-slash:before {
+  content: "\e069"; }
+
+.fa-play:before {
+  content: "\f04b"; }
+
+.fa-play-circle:before {
+  content: "\f144"; }
+
+.fa-playstation:before {
+  content: "\f3df"; }
+
+.fa-plug:before {
+  content: "\f1e6"; }
+
+.fa-plus:before {
+  content: "\f067"; }
+
+.fa-plus-circle:before {
+  content: "\f055"; }
+
+.fa-plus-square:before {
+  content: "\f0fe"; }
+
+.fa-podcast:before {
+  content: "\f2ce"; }
+
+.fa-poll:before {
+  content: "\f681"; }
+
+.fa-poll-h:before {
+  content: "\f682"; }
+
+.fa-poo:before {
+  content: "\f2fe"; }
+
+.fa-poo-storm:before {
+  content: "\f75a"; }
+
+.fa-poop:before {
+  content: "\f619"; }
+
+.fa-portrait:before {
+  content: "\f3e0"; }
+
+.fa-pound-sign:before {
+  content: "\f154"; }
+
+.fa-power-off:before {
+  content: "\f011"; }
+
+.fa-pray:before {
+  content: "\f683"; }
+
+.fa-praying-hands:before {
+  content: "\f684"; }
+
+.fa-prescription:before {
+  content: "\f5b1"; }
+
+.fa-prescription-bottle:before {
+  content: "\f485"; }
+
+.fa-prescription-bottle-alt:before {
+  content: "\f486"; }
+
+.fa-print:before {
+  content: "\f02f"; }
+
+.fa-procedures:before {
+  content: "\f487"; }
+
+.fa-product-hunt:before {
+  content: "\f288"; }
+
+.fa-project-diagram:before {
+  content: "\f542"; }
+
+.fa-pump-medical:before {
+  content: "\e06a"; }
+
+.fa-pump-soap:before {
+  content: "\e06b"; }
+
+.fa-pushed:before {
+  content: "\f3e1"; }
+
+.fa-puzzle-piece:before {
+  content: "\f12e"; }
+
+.fa-python:before {
+  content: "\f3e2"; }
+
+.fa-qq:before {
+  content: "\f1d6"; }
+
+.fa-qrcode:before {
+  content: "\f029"; }
+
+.fa-question:before {
+  content: "\f128"; }
+
+.fa-question-circle:before {
+  content: "\f059"; }
+
+.fa-quidditch:before {
+  content: "\f458"; }
+
+.fa-quinscape:before {
+  content: "\f459"; }
+
+.fa-quora:before {
+  content: "\f2c4"; }
+
+.fa-quote-left:before {
+  content: "\f10d"; }
+
+.fa-quote-right:before {
+  content: "\f10e"; }
+
+.fa-quran:before {
+  content: "\f687"; }
+
+.fa-r-project:before {
+  content: "\f4f7"; }
+
+.fa-radiation:before {
+  content: "\f7b9"; }
+
+.fa-radiation-alt:before {
+  content: "\f7ba"; }
+
+.fa-rainbow:before {
+  content: "\f75b"; }
+
+.fa-random:before {
+  content: "\f074"; }
+
+.fa-raspberry-pi:before {
+  content: "\f7bb"; }
+
+.fa-ravelry:before {
+  content: "\f2d9"; }
+
+.fa-react:before {
+  content: "\f41b"; }
+
+.fa-reacteurope:before {
+  content: "\f75d"; }
+
+.fa-readme:before {
+  content: "\f4d5"; }
+
+.fa-rebel:before {
+  content: "\f1d0"; }
+
+.fa-receipt:before {
+  content: "\f543"; }
+
+.fa-record-vinyl:before {
+  content: "\f8d9"; }
+
+.fa-recycle:before {
+  content: "\f1b8"; }
+
+.fa-red-river:before {
+  content: "\f3e3"; }
+
+.fa-reddit:before {
+  content: "\f1a1"; }
+
+.fa-reddit-alien:before {
+  content: "\f281"; }
+
+.fa-reddit-square:before {
+  content: "\f1a2"; }
+
+.fa-redhat:before {
+  content: "\f7bc"; }
+
+.fa-redo:before {
+  content: "\f01e"; }
+
+.fa-redo-alt:before {
+  content: "\f2f9"; }
+
+.fa-registered:before {
+  content: "\f25d"; }
+
+.fa-remove-format:before {
+  content: "\f87d"; }
+
+.fa-renren:before {
+  content: "\f18b"; }
+
+.fa-reply:before {
+  content: "\f3e5"; }
+
+.fa-reply-all:before {
+  content: "\f122"; }
+
+.fa-replyd:before {
+  content: "\f3e6"; }
+
+.fa-republican:before {
+  content: "\f75e"; }
+
+.fa-researchgate:before {
+  content: "\f4f8"; }
+
+.fa-resolving:before {
+  content: "\f3e7"; }
+
+.fa-restroom:before {
+  content: "\f7bd"; }
+
+.fa-retweet:before {
+  content: "\f079"; }
+
+.fa-rev:before {
+  content: "\f5b2"; }
+
+.fa-ribbon:before {
+  content: "\f4d6"; }
+
+.fa-ring:before {
+  content: "\f70b"; }
+
+.fa-road:before {
+  content: "\f018"; }
+
+.fa-robot:before {
+  content: "\f544"; }
+
+.fa-rocket:before {
+  content: "\f135"; }
+
+.fa-rocketchat:before {
+  content: "\f3e8"; }
+
+.fa-rockrms:before {
+  content: "\f3e9"; }
+
+.fa-route:before {
+  content: "\f4d7"; }
+
+.fa-rss:before {
+  content: "\f09e"; }
+
+.fa-rss-square:before {
+  content: "\f143"; }
+
+.fa-ruble-sign:before {
+  content: "\f158"; }
+
+.fa-ruler:before {
+  content: "\f545"; }
+
+.fa-ruler-combined:before {
+  content: "\f546"; }
+
+.fa-ruler-horizontal:before {
+  content: "\f547"; }
+
+.fa-ruler-vertical:before {
+  content: "\f548"; }
+
+.fa-running:before {
+  content: "\f70c"; }
+
+.fa-rupee-sign:before {
+  content: "\f156"; }
+
+.fa-rust:before {
+  content: "\e07a"; }
+
+.fa-sad-cry:before {
+  content: "\f5b3"; }
+
+.fa-sad-tear:before {
+  content: "\f5b4"; }
+
+.fa-safari:before {
+  content: "\f267"; }
+
+.fa-salesforce:before {
+  content: "\f83b"; }
+
+.fa-sass:before {
+  content: "\f41e"; }
+
+.fa-satellite:before {
+  content: "\f7bf"; }
+
+.fa-satellite-dish:before {
+  content: "\f7c0"; }
+
+.fa-save:before {
+  content: "\f0c7"; }
+
+.fa-schlix:before {
+  content: "\f3ea"; }
+
+.fa-school:before {
+  content: "\f549"; }
+
+.fa-screwdriver:before {
+  content: "\f54a"; }
+
+.fa-scribd:before {
+  content: "\f28a"; }
+
+.fa-scroll:before {
+  content: "\f70e"; }
+
+.fa-sd-card:before {
+  content: "\f7c2"; }
+
+.fa-search:before {
+  content: "\f002"; }
+
+.fa-search-dollar:before {
+  content: "\f688"; }
+
+.fa-search-location:before {
+  content: "\f689"; }
+
+.fa-search-minus:before {
+  content: "\f010"; }
+
+.fa-search-plus:before {
+  content: "\f00e"; }
+
+.fa-searchengin:before {
+  content: "\f3eb"; }
+
+.fa-seedling:before {
+  content: "\f4d8"; }
+
+.fa-sellcast:before {
+  content: "\f2da"; }
+
+.fa-sellsy:before {
+  content: "\f213"; }
+
+.fa-server:before {
+  content: "\f233"; }
+
+.fa-servicestack:before {
+  content: "\f3ec"; }
+
+.fa-shapes:before {
+  content: "\f61f"; }
+
+.fa-share:before {
+  content: "\f064"; }
+
+.fa-share-alt:before {
+  content: "\f1e0"; }
+
+.fa-share-alt-square:before {
+  content: "\f1e1"; }
+
+.fa-share-square:before {
+  content: "\f14d"; }
+
+.fa-shekel-sign:before {
+  content: "\f20b"; }
+
+.fa-shield-alt:before {
+  content: "\f3ed"; }
+
+.fa-shield-virus:before {
+  content: "\e06c"; }
+
+.fa-ship:before {
+  content: "\f21a"; }
+
+.fa-shipping-fast:before {
+  content: "\f48b"; }
+
+.fa-shirtsinbulk:before {
+  content: "\f214"; }
+
+.fa-shoe-prints:before {
+  content: "\f54b"; }
+
+.fa-shopify:before {
+  content: "\e057"; }
+
+.fa-shopping-bag:before {
+  content: "\f290"; }
+
+.fa-shopping-basket:before {
+  content: "\f291"; }
+
+.fa-shopping-cart:before {
+  content: "\f07a"; }
+
+.fa-shopware:before {
+  content: "\f5b5"; }
+
+.fa-shower:before {
+  content: "\f2cc"; }
+
+.fa-shuttle-van:before {
+  content: "\f5b6"; }
+
+.fa-sign:before {
+  content: "\f4d9"; }
+
+.fa-sign-in-alt:before {
+  content: "\f2f6"; }
+
+.fa-sign-language:before {
+  content: "\f2a7"; }
+
+.fa-sign-out-alt:before {
+  content: "\f2f5"; }
+
+.fa-signal:before {
+  content: "\f012"; }
+
+.fa-signature:before {
+  content: "\f5b7"; }
+
+.fa-sim-card:before {
+  content: "\f7c4"; }
+
+.fa-simplybuilt:before {
+  content: "\f215"; }
+
+.fa-sink:before {
+  content: "\e06d"; }
+
+.fa-sistrix:before {
+  content: "\f3ee"; }
+
+.fa-sitemap:before {
+  content: "\f0e8"; }
+
+.fa-sith:before {
+  content: "\f512"; }
+
+.fa-skating:before {
+  content: "\f7c5"; }
+
+.fa-sketch:before {
+  content: "\f7c6"; }
+
+.fa-skiing:before {
+  content: "\f7c9"; }
+
+.fa-skiing-nordic:before {
+  content: "\f7ca"; }
+
+.fa-skull:before {
+  content: "\f54c"; }
+
+.fa-skull-crossbones:before {
+  content: "\f714"; }
+
+.fa-skyatlas:before {
+  content: "\f216"; }
+
+.fa-skype:before {
+  content: "\f17e"; }
+
+.fa-slack:before {
+  content: "\f198"; }
+
+.fa-slack-hash:before {
+  content: "\f3ef"; }
+
+.fa-slash:before {
+  content: "\f715"; }
+
+.fa-sleigh:before {
+  content: "\f7cc"; }
+
+.fa-sliders-h:before {
+  content: "\f1de"; }
+
+.fa-slideshare:before {
+  content: "\f1e7"; }
+
+.fa-smile:before {
+  content: "\f118"; }
+
+.fa-smile-beam:before {
+  content: "\f5b8"; }
+
+.fa-smile-wink:before {
+  content: "\f4da"; }
+
+.fa-smog:before {
+  content: "\f75f"; }
+
+.fa-smoking:before {
+  content: "\f48d"; }
+
+.fa-smoking-ban:before {
+  content: "\f54d"; }
+
+.fa-sms:before {
+  content: "\f7cd"; }
+
+.fa-snapchat:before {
+  content: "\f2ab"; }
+
+.fa-snapchat-ghost:before {
+  content: "\f2ac"; }
+
+.fa-snapchat-square:before {
+  content: "\f2ad"; }
+
+.fa-snowboarding:before {
+  content: "\f7ce"; }
+
+.fa-snowflake:before {
+  content: "\f2dc"; }
+
+.fa-snowman:before {
+  content: "\f7d0"; }
+
+.fa-snowplow:before {
+  content: "\f7d2"; }
+
+.fa-soap:before {
+  content: "\e06e"; }
+
+.fa-socks:before {
+  content: "\f696"; }
+
+.fa-solar-panel:before {
+  content: "\f5ba"; }
+
+.fa-sort:before {
+  content: "\f0dc"; }
+
+.fa-sort-alpha-down:before {
+  content: "\f15d"; }
+
+.fa-sort-alpha-down-alt:before {
+  content: "\f881"; }
+
+.fa-sort-alpha-up:before {
+  content: "\f15e"; }
+
+.fa-sort-alpha-up-alt:before {
+  content: "\f882"; }
+
+.fa-sort-amount-down:before {
+  content: "\f160"; }
+
+.fa-sort-amount-down-alt:before {
+  content: "\f884"; }
+
+.fa-sort-amount-up:before {
+  content: "\f161"; }
+
+.fa-sort-amount-up-alt:before {
+  content: "\f885"; }
+
+.fa-sort-down:before {
+  content: "\f0dd"; }
+
+.fa-sort-numeric-down:before {
+  content: "\f162"; }
+
+.fa-sort-numeric-down-alt:before {
+  content: "\f886"; }
+
+.fa-sort-numeric-up:before {
+  content: "\f163"; }
+
+.fa-sort-numeric-up-alt:before {
+  content: "\f887"; }
+
+.fa-sort-up:before {
+  content: "\f0de"; }
+
+.fa-soundcloud:before {
+  content: "\f1be"; }
+
+.fa-sourcetree:before {
+  content: "\f7d3"; }
+
+.fa-spa:before {
+  content: "\f5bb"; }
+
+.fa-space-shuttle:before {
+  content: "\f197"; }
+
+.fa-speakap:before {
+  content: "\f3f3"; }
+
+.fa-speaker-deck:before {
+  content: "\f83c"; }
+
+.fa-spell-check:before {
+  content: "\f891"; }
+
+.fa-spider:before {
+  content: "\f717"; }
+
+.fa-spinner:before {
+  content: "\f110"; }
+
+.fa-splotch:before {
+  content: "\f5bc"; }
+
+.fa-spotify:before {
+  content: "\f1bc"; }
+
+.fa-spray-can:before {
+  content: "\f5bd"; }
+
+.fa-square:before {
+  content: "\f0c8"; }
+
+.fa-square-full:before {
+  content: "\f45c"; }
+
+.fa-square-root-alt:before {
+  content: "\f698"; }
+
+.fa-squarespace:before {
+  content: "\f5be"; }
+
+.fa-stack-exchange:before {
+  content: "\f18d"; }
+
+.fa-stack-overflow:before {
+  content: "\f16c"; }
+
+.fa-stackpath:before {
+  content: "\f842"; }
+
+.fa-stamp:before {
+  content: "\f5bf"; }
+
+.fa-star:before {
+  content: "\f005"; }
+
+.fa-star-and-crescent:before {
+  content: "\f699"; }
+
+.fa-star-half:before {
+  content: "\f089"; }
+
+.fa-star-half-alt:before {
+  content: "\f5c0"; }
+
+.fa-star-of-david:before {
+  content: "\f69a"; }
+
+.fa-star-of-life:before {
+  content: "\f621"; }
+
+.fa-staylinked:before {
+  content: "\f3f5"; }
+
+.fa-steam:before {
+  content: "\f1b6"; }
+
+.fa-steam-square:before {
+  content: "\f1b7"; }
+
+.fa-steam-symbol:before {
+  content: "\f3f6"; }
+
+.fa-step-backward:before {
+  content: "\f048"; }
+
+.fa-step-forward:before {
+  content: "\f051"; }
+
+.fa-stethoscope:before {
+  content: "\f0f1"; }
+
+.fa-sticker-mule:before {
+  content: "\f3f7"; }
+
+.fa-sticky-note:before {
+  content: "\f249"; }
+
+.fa-stop:before {
+  content: "\f04d"; }
+
+.fa-stop-circle:before {
+  content: "\f28d"; }
+
+.fa-stopwatch:before {
+  content: "\f2f2"; }
+
+.fa-stopwatch-20:before {
+  content: "\e06f"; }
+
+.fa-store:before {
+  content: "\f54e"; }
+
+.fa-store-alt:before {
+  content: "\f54f"; }
+
+.fa-store-alt-slash:before {
+  content: "\e070"; }
+
+.fa-store-slash:before {
+  content: "\e071"; }
+
+.fa-strava:before {
+  content: "\f428"; }
+
+.fa-stream:before {
+  content: "\f550"; }
+
+.fa-street-view:before {
+  content: "\f21d"; }
+
+.fa-strikethrough:before {
+  content: "\f0cc"; }
+
+.fa-stripe:before {
+  content: "\f429"; }
+
+.fa-stripe-s:before {
+  content: "\f42a"; }
+
+.fa-stroopwafel:before {
+  content: "\f551"; }
+
+.fa-studiovinari:before {
+  content: "\f3f8"; }
+
+.fa-stumbleupon:before {
+  content: "\f1a4"; }
+
+.fa-stumbleupon-circle:before {
+  content: "\f1a3"; }
+
+.fa-subscript:before {
+  content: "\f12c"; }
+
+.fa-subway:before {
+  content: "\f239"; }
+
+.fa-suitcase:before {
+  content: "\f0f2"; }
+
+.fa-suitcase-rolling:before {
+  content: "\f5c1"; }
+
+.fa-sun:before {
+  content: "\f185"; }
+
+.fa-superpowers:before {
+  content: "\f2dd"; }
+
+.fa-superscript:before {
+  content: "\f12b"; }
+
+.fa-supple:before {
+  content: "\f3f9"; }
+
+.fa-surprise:before {
+  content: "\f5c2"; }
+
+.fa-suse:before {
+  content: "\f7d6"; }
+
+.fa-swatchbook:before {
+  content: "\f5c3"; }
+
+.fa-swift:before {
+  content: "\f8e1"; }
+
+.fa-swimmer:before {
+  content: "\f5c4"; }
+
+.fa-swimming-pool:before {
+  content: "\f5c5"; }
+
+.fa-symfony:before {
+  content: "\f83d"; }
+
+.fa-synagogue:before {
+  content: "\f69b"; }
+
+.fa-sync:before {
+  content: "\f021"; }
+
+.fa-sync-alt:before {
+  content: "\f2f1"; }
+
+.fa-syringe:before {
+  content: "\f48e"; }
+
+.fa-table:before {
+  content: "\f0ce"; }
+
+.fa-table-tennis:before {
+  content: "\f45d"; }
+
+.fa-tablet:before {
+  content: "\f10a"; }
+
+.fa-tablet-alt:before {
+  content: "\f3fa"; }
+
+.fa-tablets:before {
+  content: "\f490"; }
+
+.fa-tachometer-alt:before {
+  content: "\f3fd"; }
+
+.fa-tag:before {
+  content: "\f02b"; }
+
+.fa-tags:before {
+  content: "\f02c"; }
+
+.fa-tape:before {
+  content: "\f4db"; }
+
+.fa-tasks:before {
+  content: "\f0ae"; }
+
+.fa-taxi:before {
+  content: "\f1ba"; }
+
+.fa-teamspeak:before {
+  content: "\f4f9"; }
+
+.fa-teeth:before {
+  content: "\f62e"; }
+
+.fa-teeth-open:before {
+  content: "\f62f"; }
+
+.fa-telegram:before {
+  content: "\f2c6"; }
+
+.fa-telegram-plane:before {
+  content: "\f3fe"; }
+
+.fa-temperature-high:before {
+  content: "\f769"; }
+
+.fa-temperature-low:before {
+  content: "\f76b"; }
+
+.fa-tencent-weibo:before {
+  content: "\f1d5"; }
+
+.fa-tenge:before {
+  content: "\f7d7"; }
+
+.fa-terminal:before {
+  content: "\f120"; }
+
+.fa-text-height:before {
+  content: "\f034"; }
+
+.fa-text-width:before {
+  content: "\f035"; }
+
+.fa-th:before {
+  content: "\f00a"; }
+
+.fa-th-large:before {
+  content: "\f009"; }
+
+.fa-th-list:before {
+  content: "\f00b"; }
+
+.fa-the-red-yeti:before {
+  content: "\f69d"; }
+
+.fa-theater-masks:before {
+  content: "\f630"; }
+
+.fa-themeco:before {
+  content: "\f5c6"; }
+
+.fa-themeisle:before {
+  content: "\f2b2"; }
+
+.fa-thermometer:before {
+  content: "\f491"; }
+
+.fa-thermometer-empty:before {
+  content: "\f2cb"; }
+
+.fa-thermometer-full:before {
+  content: "\f2c7"; }
+
+.fa-thermometer-half:before {
+  content: "\f2c9"; }
+
+.fa-thermometer-quarter:before {
+  content: "\f2ca"; }
+
+.fa-thermometer-three-quarters:before {
+  content: "\f2c8"; }
+
+.fa-think-peaks:before {
+  content: "\f731"; }
+
+.fa-thumbs-down:before {
+  content: "\f165"; }
+
+.fa-thumbs-up:before {
+  content: "\f164"; }
+
+.fa-thumbtack:before {
+  content: "\f08d"; }
+
+.fa-ticket-alt:before {
+  content: "\f3ff"; }
+
+.fa-tiktok:before {
+  content: "\e07b"; }
+
+.fa-times:before {
+  content: "\f00d"; }
+
+.fa-times-circle:before {
+  content: "\f057"; }
+
+.fa-tint:before {
+  content: "\f043"; }
+
+.fa-tint-slash:before {
+  content: "\f5c7"; }
+
+.fa-tired:before {
+  content: "\f5c8"; }
+
+.fa-toggle-off:before {
+  content: "\f204"; }
+
+.fa-toggle-on:before {
+  content: "\f205"; }
+
+.fa-toilet:before {
+  content: "\f7d8"; }
+
+.fa-toilet-paper:before {
+  content: "\f71e"; }
+
+.fa-toilet-paper-slash:before {
+  content: "\e072"; }
+
+.fa-toolbox:before {
+  content: "\f552"; }
+
+.fa-tools:before {
+  content: "\f7d9"; }
+
+.fa-tooth:before {
+  content: "\f5c9"; }
+
+.fa-torah:before {
+  content: "\f6a0"; }
+
+.fa-torii-gate:before {
+  content: "\f6a1"; }
+
+.fa-tractor:before {
+  content: "\f722"; }
+
+.fa-trade-federation:before {
+  content: "\f513"; }
+
+.fa-trademark:before {
+  content: "\f25c"; }
+
+.fa-traffic-light:before {
+  content: "\f637"; }
+
+.fa-trailer:before {
+  content: "\e041"; }
+
+.fa-train:before {
+  content: "\f238"; }
+
+.fa-tram:before {
+  content: "\f7da"; }
+
+.fa-transgender:before {
+  content: "\f224"; }
+
+.fa-transgender-alt:before {
+  content: "\f225"; }
+
+.fa-trash:before {
+  content: "\f1f8"; }
+
+.fa-trash-alt:before {
+  content: "\f2ed"; }
+
+.fa-trash-restore:before {
+  content: "\f829"; }
+
+.fa-trash-restore-alt:before {
+  content: "\f82a"; }
+
+.fa-tree:before {
+  content: "\f1bb"; }
+
+.fa-trello:before {
+  content: "\f181"; }
+
+.fa-tripadvisor:before {
+  content: "\f262"; }
+
+.fa-trophy:before {
+  content: "\f091"; }
+
+.fa-truck:before {
+  content: "\f0d1"; }
+
+.fa-truck-loading:before {
+  content: "\f4de"; }
+
+.fa-truck-monster:before {
+  content: "\f63b"; }
+
+.fa-truck-moving:before {
+  content: "\f4df"; }
+
+.fa-truck-pickup:before {
+  content: "\f63c"; }
+
+.fa-tshirt:before {
+  content: "\f553"; }
+
+.fa-tty:before {
+  content: "\f1e4"; }
+
+.fa-tumblr:before {
+  content: "\f173"; }
+
+.fa-tumblr-square:before {
+  content: "\f174"; }
+
+.fa-tv:before {
+  content: "\f26c"; }
+
+.fa-twitch:before {
+  content: "\f1e8"; }
+
+.fa-twitter:before {
+  content: "\f099"; }
+
+.fa-twitter-square:before {
+  content: "\f081"; }
+
+.fa-typo3:before {
+  content: "\f42b"; }
+
+.fa-uber:before {
+  content: "\f402"; }
+
+.fa-ubuntu:before {
+  content: "\f7df"; }
+
+.fa-uikit:before {
+  content: "\f403"; }
+
+.fa-umbraco:before {
+  content: "\f8e8"; }
+
+.fa-umbrella:before {
+  content: "\f0e9"; }
+
+.fa-umbrella-beach:before {
+  content: "\f5ca"; }
+
+.fa-uncharted:before {
+  content: "\e084"; }
+
+.fa-underline:before {
+  content: "\f0cd"; }
+
+.fa-undo:before {
+  content: "\f0e2"; }
+
+.fa-undo-alt:before {
+  content: "\f2ea"; }
+
+.fa-uniregistry:before {
+  content: "\f404"; }
+
+.fa-unity:before {
+  content: "\e049"; }
+
+.fa-universal-access:before {
+  content: "\f29a"; }
+
+.fa-university:before {
+  content: "\f19c"; }
+
+.fa-unlink:before {
+  content: "\f127"; }
+
+.fa-unlock:before {
+  content: "\f09c"; }
+
+.fa-unlock-alt:before {
+  content: "\f13e"; }
+
+.fa-unsplash:before {
+  content: "\e07c"; }
+
+.fa-untappd:before {
+  content: "\f405"; }
+
+.fa-upload:before {
+  content: "\f093"; }
+
+.fa-ups:before {
+  content: "\f7e0"; }
+
+.fa-usb:before {
+  content: "\f287"; }
+
+.fa-user:before {
+  content: "\f007"; }
+
+.fa-user-alt:before {
+  content: "\f406"; }
+
+.fa-user-alt-slash:before {
+  content: "\f4fa"; }
+
+.fa-user-astronaut:before {
+  content: "\f4fb"; }
+
+.fa-user-check:before {
+  content: "\f4fc"; }
+
+.fa-user-circle:before {
+  content: "\f2bd"; }
+
+.fa-user-clock:before {
+  content: "\f4fd"; }
+
+.fa-user-cog:before {
+  content: "\f4fe"; }
+
+.fa-user-edit:before {
+  content: "\f4ff"; }
+
+.fa-user-friends:before {
+  content: "\f500"; }
+
+.fa-user-graduate:before {
+  content: "\f501"; }
+
+.fa-user-injured:before {
+  content: "\f728"; }
+
+.fa-user-lock:before {
+  content: "\f502"; }
+
+.fa-user-md:before {
+  content: "\f0f0"; }
+
+.fa-user-minus:before {
+  content: "\f503"; }
+
+.fa-user-ninja:before {
+  content: "\f504"; }
+
+.fa-user-nurse:before {
+  content: "\f82f"; }
+
+.fa-user-plus:before {
+  content: "\f234"; }
+
+.fa-user-secret:before {
+  content: "\f21b"; }
+
+.fa-user-shield:before {
+  content: "\f505"; }
+
+.fa-user-slash:before {
+  content: "\f506"; }
+
+.fa-user-tag:before {
+  content: "\f507"; }
+
+.fa-user-tie:before {
+  content: "\f508"; }
+
+.fa-user-times:before {
+  content: "\f235"; }
+
+.fa-users:before {
+  content: "\f0c0"; }
+
+.fa-users-cog:before {
+  content: "\f509"; }
+
+.fa-users-slash:before {
+  content: "\e073"; }
+
+.fa-usps:before {
+  content: "\f7e1"; }
+
+.fa-ussunnah:before {
+  content: "\f407"; }
+
+.fa-utensil-spoon:before {
+  content: "\f2e5"; }
+
+.fa-utensils:before {
+  content: "\f2e7"; }
+
+.fa-vaadin:before {
+  content: "\f408"; }
+
+.fa-vector-square:before {
+  content: "\f5cb"; }
+
+.fa-venus:before {
+  content: "\f221"; }
+
+.fa-venus-double:before {
+  content: "\f226"; }
+
+.fa-venus-mars:before {
+  content: "\f228"; }
+
+.fa-vest:before {
+  content: "\e085"; }
+
+.fa-vest-patches:before {
+  content: "\e086"; }
+
+.fa-viacoin:before {
+  content: "\f237"; }
+
+.fa-viadeo:before {
+  content: "\f2a9"; }
+
+.fa-viadeo-square:before {
+  content: "\f2aa"; }
+
+.fa-vial:before {
+  content: "\f492"; }
+
+.fa-vials:before {
+  content: "\f493"; }
+
+.fa-viber:before {
+  content: "\f409"; }
+
+.fa-video:before {
+  content: "\f03d"; }
+
+.fa-video-slash:before {
+  content: "\f4e2"; }
+
+.fa-vihara:before {
+  content: "\f6a7"; }
+
+.fa-vimeo:before {
+  content: "\f40a"; }
+
+.fa-vimeo-square:before {
+  content: "\f194"; }
+
+.fa-vimeo-v:before {
+  content: "\f27d"; }
+
+.fa-vine:before {
+  content: "\f1ca"; }
+
+.fa-virus:before {
+  content: "\e074"; }
+
+.fa-virus-slash:before {
+  content: "\e075"; }
+
+.fa-viruses:before {
+  content: "\e076"; }
+
+.fa-vk:before {
+  content: "\f189"; }
+
+.fa-vnv:before {
+  content: "\f40b"; }
+
+.fa-voicemail:before {
+  content: "\f897"; }
+
+.fa-volleyball-ball:before {
+  content: "\f45f"; }
+
+.fa-volume-down:before {
+  content: "\f027"; }
+
+.fa-volume-mute:before {
+  content: "\f6a9"; }
+
+.fa-volume-off:before {
+  content: "\f026"; }
+
+.fa-volume-up:before {
+  content: "\f028"; }
+
+.fa-vote-yea:before {
+  content: "\f772"; }
+
+.fa-vr-cardboard:before {
+  content: "\f729"; }
+
+.fa-vuejs:before {
+  content: "\f41f"; }
+
+.fa-walking:before {
+  content: "\f554"; }
+
+.fa-wallet:before {
+  content: "\f555"; }
+
+.fa-warehouse:before {
+  content: "\f494"; }
+
+.fa-watchman-monitoring:before {
+  content: "\e087"; }
+
+.fa-water:before {
+  content: "\f773"; }
+
+.fa-wave-square:before {
+  content: "\f83e"; }
+
+.fa-waze:before {
+  content: "\f83f"; }
+
+.fa-weebly:before {
+  content: "\f5cc"; }
+
+.fa-weibo:before {
+  content: "\f18a"; }
+
+.fa-weight:before {
+  content: "\f496"; }
+
+.fa-weight-hanging:before {
+  content: "\f5cd"; }
+
+.fa-weixin:before {
+  content: "\f1d7"; }
+
+.fa-whatsapp:before {
+  content: "\f232"; }
+
+.fa-whatsapp-square:before {
+  content: "\f40c"; }
+
+.fa-wheelchair:before {
+  content: "\f193"; }
+
+.fa-whmcs:before {
+  content: "\f40d"; }
+
+.fa-wifi:before {
+  content: "\f1eb"; }
+
+.fa-wikipedia-w:before {
+  content: "\f266"; }
+
+.fa-wind:before {
+  content: "\f72e"; }
+
+.fa-window-close:before {
+  content: "\f410"; }
+
+.fa-window-maximize:before {
+  content: "\f2d0"; }
+
+.fa-window-minimize:before {
+  content: "\f2d1"; }
+
+.fa-window-restore:before {
+  content: "\f2d2"; }
+
+.fa-windows:before {
+  content: "\f17a"; }
+
+.fa-wine-bottle:before {
+  content: "\f72f"; }
+
+.fa-wine-glass:before {
+  content: "\f4e3"; }
+
+.fa-wine-glass-alt:before {
+  content: "\f5ce"; }
+
+.fa-wix:before {
+  content: "\f5cf"; }
+
+.fa-wizards-of-the-coast:before {
+  content: "\f730"; }
+
+.fa-wodu:before {
+  content: "\e088"; }
+
+.fa-wolf-pack-battalion:before {
+  content: "\f514"; }
+
+.fa-won-sign:before {
+  content: "\f159"; }
+
+.fa-wordpress:before {
+  content: "\f19a"; }
+
+.fa-wordpress-simple:before {
+  content: "\f411"; }
+
+.fa-wpbeginner:before {
+  content: "\f297"; }
+
+.fa-wpexplorer:before {
+  content: "\f2de"; }
+
+.fa-wpforms:before {
+  content: "\f298"; }
+
+.fa-wpressr:before {
+  content: "\f3e4"; }
+
+.fa-wrench:before {
+  content: "\f0ad"; }
+
+.fa-x-ray:before {
+  content: "\f497"; }
+
+.fa-xbox:before {
+  content: "\f412"; }
+
+.fa-xing:before {
+  content: "\f168"; }
+
+.fa-xing-square:before {
+  content: "\f169"; }
+
+.fa-y-combinator:before {
+  content: "\f23b"; }
+
+.fa-yahoo:before {
+  content: "\f19e"; }
+
+.fa-yammer:before {
+  content: "\f840"; }
+
+.fa-yandex:before {
+  content: "\f413"; }
+
+.fa-yandex-international:before {
+  content: "\f414"; }
+
+.fa-yarn:before {
+  content: "\f7e3"; }
+
+.fa-yelp:before {
+  content: "\f1e9"; }
+
+.fa-yen-sign:before {
+  content: "\f157"; }
+
+.fa-yin-yang:before {
+  content: "\f6ad"; }
+
+.fa-yoast:before {
+  content: "\f2b1"; }
+
+.fa-youtube:before {
+  content: "\f167"; }
+
+.fa-youtube-square:before {
+  content: "\f431"; }
+
+.fa-zhihu:before {
+  content: "\f63f"; }
+
+.sr-only {
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px; }
+
+.sr-only-focusable:active, .sr-only-focusable:focus {
+  clip: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  position: static;
+  width: auto; }
+
+/*!
+ * Font Awesome Free 5.15.3 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+ */
+@font-face {
+  font-family: 'Font Awesome 5 Brands';
+  font-style: normal;
+  font-weight: 400;
+  font-display: block;
+  src: url("../fonts/fontawesome-free/webfonts/fa-brands-400.eot");
+  src: url("../fonts/fontawesome-free/webfonts/fa-brands-400.eot?#iefix") format("embedded-opentype"), url("../fonts/fontawesome-free/webfonts/fa-brands-400.woff2") format("woff2"), url("../fonts/fontawesome-free/webfonts/fa-brands-400.woff") format("woff"), url("../fonts/fontawesome-free/webfonts/fa-brands-400.ttf") format("truetype"), url("../fonts/fontawesome-free/webfonts/fa-brands-400.svg#fontawesome") format("svg"); }
+
+.fab {
+  font-family: 'Font Awesome 5 Brands';
+  font-weight: 400; }
+
+/*!
+ * Font Awesome Free 5.15.3 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+ */
+@font-face {
+  font-family: 'Font Awesome 5 Free';
+  font-style: normal;
+  font-weight: 900;
+  font-display: block;
+  src: url("../fonts/fontawesome-free/webfonts/fa-solid-900.eot");
+  src: url("../fonts/fontawesome-free/webfonts/fa-solid-900.eot?#iefix") format("embedded-opentype"), url("../fonts/fontawesome-free/webfonts/fa-solid-900.woff2") format("woff2"), url("../fonts/fontawesome-free/webfonts/fa-solid-900.woff") format("woff"), url("../fonts/fontawesome-free/webfonts/fa-solid-900.ttf") format("truetype"), url("../fonts/fontawesome-free/webfonts/fa-solid-900.svg#fontawesome") format("svg"); }
+
+.fa,
+.fas {
+  font-family: 'Font Awesome 5 Free';
+  font-weight: 900; }
+
+html, body {
+  background-color: #ffffff; }
+
+html {
+  scroll-behavior: smooth; }
+
+html.modal-open {
+  overflow: hidden; }
+
+@keyframes fadeIn {
+  from {
+    opacity: 0; }
+  to {
+    opacity: 1; } }
+
+.fade-in {
+  opacity: 0;
+  animation: fadeIn ease-in 1;
+  animation-fill-mode: forwards;
+  animation-duration: 1s; }
+  .fade-in.one {
+    animation-delay: 0.7s; }
+  .fade-in.two {
+    animation-delay: 1.4s; }
+  .fade-in.three {
+    animation-delay: 1.8s; }
+
+a {
+  color: #00b8d4; }
+  a:hover {
+    color: #000000;
+    font-style: none; }
+  a:active {
+    color: #00b8d4; }
+
+h1, h2, .title, .subtitle {
+  color: #222222; }
+
+p {
+  color: #4a4a4a; }
+
+.title {
+  font-weight: 300; }
+
+ul {
+  padding: 0; }
+
+img {
+  border-radius: 5px;
+  border: 1px solid #dbdbdb;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.4); }
+
+hr {
+  background-color: #dbdbdb;
+  height: 1px; }
+
+details {
+  padding: .5em .5em 0; }
+
+summary {
+  margin: -.5em -.5em 0;
+  padding: .5em;
+  cursor: pointer; }
+
+details[open] {
+  padding: .5em; }
+
+details[open] summary {
+  margin-bottom: .5em; }
+
+.container {
+  max-width: 1000px; }
+
+.noborder {
+  border-radius: 0px;
+  border: none;
+  box-shadow: none; }
+
+.hidden {
+  display: none; }
+
+.img-responsive {
+  border-radius: 5px;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.4); }
+
+.avatar {
+  border: none; }
+  @media screen and (max-width: 768px) {
+    .avatar {
+      max-width: 50%; } }
+.thumbnail {
+  border: none; }
+
+.card-thumbnail {
+  width: 100%;
+  height: 100%;
+  object-fit: cover; }
+
+.bold-title {
+  font-size: 6rem;
+  line-height: 1.2;
+  margin-bottom: 0.25em; }
+  @media screen and (max-width: 768px) {
+    .bold-title {
+      font-size: 3rem;
+      text-align: center; } }
+.top-pad {
+  padding-top: 1rem; }
+
+.bottom-pad {
+  padding-bottom: 1rem; }
+
+.strong-post-title {
+  font-weight: 700; }
+
+.post-item {
+  display: block;
+  list-style: none;
+  list-style-position: outside;
+  margin-left: 0; }
+
+.post-data, .blog-share, .footer-text {
+  font-size: 1rem;
+  line-height: 2rem;
+  color: #4a4a4a; }
+
+.social-icons {
+  padding: 0 10px; }
+  .social-icons a {
+    margin: 0 5px; }
+
+.icon {
+  height: 2rem;
+  width: 2rem;
+  margin: 0 10px; }
+
+.fab {
+  font-size: 1.3rem; }
+
+.blog-share .icon {
+  height: 1rem;
+  width: 1rem;
+  vertical-align: baseline;
+  margin: 0 5px; }
+
+.navbar {
+  background-color: #ffffff; }
+
+.navbar-burger {
+  margin-right: auto;
+  color: #00b8d4; }
+
+.navbar-burger:hover {
+  background-color: #ffffff; }
+
+.navbar-item {
+  text-transform: uppercase;
+  font-size: 0.875rem;
+  color: #4a4a4a; }
+  .navbar-item:hover, .navbar-item:active {
+    background-color: #ffffff !important; }
+
+.owl-nav {
+  height: 50px; }
+
+.owl-next, .owl-prev {
+  height: 30px; }
+  .owl-next span, .owl-prev span {
+    font-size: 3rem;
+    line-height: 30px; }
+
+.footer-text {
+  font-size: 0.8em; }
+  .footer-text a {
+    color: #4a4a4a; }
+  .footer-text .fab {
+    font-size: 0.8em;
+    vertical-align: baseline; }
+
+.tags-list {
+  width: 70%;
+  margin: 0 auto;
+  text-align: center;
+  font-size: 1.5rem; }
+  @media screen and (max-width: 768px) {
+    .tags-list {
+      width: 100%; } }
+.tag-cloud {
+  font-size: 1.5rem;
+  margin-right: 1.5rem; }
+  @media screen and (max-width: 768px) {
+    .tag-cloud {
+      font-size: 1.5rem;
+      margin-right: 1rem; } }
+.card {
+  box-shadow: none; }
+
+.card-content {
+  background-color: #ffffff;
+  font-size: 1.5rem; }
+
+.has-content-centered {
+  justify-content: center; }
+
+.markdown {
+  color: #4a4a4a !important; }
+  .markdown p {
+    margin: 1em 0; }
+  .markdown h1 {
+    font-size: 3rem; }
+    @media screen and (max-width: 768px) {
+      .markdown h1 {
+        font-size: 2.5rem; } }
+  .markdown h2 {
+    font-size: 2.5rem;
+    line-height: 1em;
+    margin-top: 1em;
+    margin-bottom: 0.5em; }
+    @media screen and (max-width: 768px) {
+      .markdown h2 {
+        font-size: 2rem; } }
+  .markdown h3 {
+    font-size: 2rem; }
+    @media screen and (max-width: 768px) {
+      .markdown h3 {
+        font-size: 1.5rem; } }
+  .markdown h4 {
+    font-size: 1.5rem; }
+    @media screen and (max-width: 768px) {
+      .markdown h4 {
+        font-size: 1.25rem; } }
+  .markdown h5 {
+    font-size: 1.25rem; }
+  .markdown h6 {
+    font-size: 1rem; }
+  .markdown a:hover {
+    color: #dbdbdb; }
+  .markdown ul {
+    margin-bottom: 1.25rem;
+    list-style: disc; }
+  .markdown ul ul {
+    margin-left: 0.5em;
+    margin-bottom: 0; }
+  .markdown li {
+    margin-left: 1em;
+    list-style-position: outside;
+    padding-left: 0.25em; }
+  .markdown ol {
+    margin-bottom: 1.25rem; }
+  .markdown ol ol {
+    margin-left: 0.5em;
+    list-style-type: lower-alpha;
+    margin-bottom: 0; }
+  .markdown ol ol ol {
+    list-style-type: lower-roman; }
+  .markdown em {
+    font-style: italic; }
+  .markdown strong {
+    font-weight: 700; }
+  .markdown hr {
+    position: relative;
+    margin: 1.75rem 0;
+    border: 0;
+    border-top: 1px solid #dbdbdb; }
+  .markdown abbr {
+    font-size: 0.8rem;
+    font-weight: bold;
+    color: #666666;
+    text-transform: uppercase; }
+  .markdown abbr[title] {
+    cursor: help;
+    border-bottom: 1px dotted #808080; }
+  .markdown blockquote {
+    padding: .5rem 1rem;
+    margin: .8rem 0;
+    color: #7a7a7a;
+    border-left: .25rem solid #e5e5e5; }
+    .markdown blockquote blockquote p:last-child {
+      margin-bottom: 0; }
+  .markdown table {
+    margin: 2em 0 2em 0;
+    width: 100%;
+    border: 1px solid #e5e5e5;
+    border-collapse: collapse; }
+  .markdown td, .markdown th {
+    padding: .25rem .5rem;
+    border: 1px solid #e5e5e5;
+    text-align: center;
+    background-color: #f7f7f7; }
+  .markdown tbody tr:nth-child(odd) td,
+  .markdown tbody tr:nth-child(odd) th {
+    background-color: #dedede; }
+  .markdown tbody tr:nth-child(even) td,
+  .markdown tbody tr:nth-child(even) th {
+    background-color: #f7f7f7; }
+  .markdown code, .markdown pre {
+    border-radius: 3px; }
+  .markdown p > code, .markdown p > a > code {
+    background-color: rgba(219, 219, 219, 0.3) !important; }
+  .markdown img {
+    display: block;
+    margin: 2rem auto;
+    max-width: 100%; }
+  .markdown figure > img {
+    margin: auto; }
+  .markdown figcaption {
+    margin: 0.5rem auto;
+    max-width: 500px;
+    text-align: center; }
+  .markdown figcaption > h4 {
+    font-size: 0.8rem; }
+
+.modal-background {
+  background-color: rgba(255, 255, 255, 0.9); }
+
+.modal-close {
+  background-color: #000000; }
+
+@media (prefers-color-scheme: dark) {
+  /* vietnamese */
+  @font-face {
+    font-family: "Nunito Sans";
+    font-style: normal;
+    font-weight: normal;
+    src: local("Nunito Sans Regular"), local("NunitoSans-Regular"), url(../fonts/NunitoSans/NunitoSans-Regular.ttf) format("woff2");
+    unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB; }
+  /* latin-ext */
+  @font-face {
+    font-family: "Nunito Sans";
+    font-style: normal;
+    font-weight: normal;
+    src: local("Nunito Sans Regular"), local("NunitoSans-Regular"), url(../fonts/NunitoSans/NunitoSans-Regular.ttf) format("woff2");
+    unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+  /* latin */
+  @font-face {
+    font-family: "Nunito Sans";
+    font-style: normal;
+    font-weight: normal;
+    src: local("Nunito Sans Regular"), local("NunitoSans-Regular"), url(../fonts/NunitoSans/NunitoSans-Regular.ttf) format("woff2");
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; }
+  /*!
+ * Font Awesome Free 5.15.3 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+ */
+  .fa,
+  .fas,
+  .far,
+  .fal,
+  .fad,
+  .fab {
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    display: inline-block;
+    font-style: normal;
+    font-variant: normal;
+    text-rendering: auto;
+    line-height: 1; }
+  .fa-lg {
+    font-size: 1.33333333em;
+    line-height: 0.75em;
+    vertical-align: -.0667em; }
+  .fa-xs {
+    font-size: .75em; }
+  .fa-sm {
+    font-size: .875em; }
+  .fa-1x {
+    font-size: 1em; }
+  .fa-2x {
+    font-size: 2em; }
+  .fa-3x {
+    font-size: 3em; }
+  .fa-4x {
+    font-size: 4em; }
+  .fa-5x {
+    font-size: 5em; }
+  .fa-6x {
+    font-size: 6em; }
+  .fa-7x {
+    font-size: 7em; }
+  .fa-8x {
+    font-size: 8em; }
+  .fa-9x {
+    font-size: 9em; }
+  .fa-10x {
+    font-size: 10em; }
+  .fa-fw {
+    text-align: center;
+    width: 1.25em; }
+  .fa-ul {
+    list-style-type: none;
+    margin-left: 2.5em;
+    padding-left: 0; }
+    .fa-ul > li {
+      position: relative; }
+  .fa-li {
+    left: -2em;
+    position: absolute;
+    text-align: center;
+    width: 2em;
+    line-height: inherit; }
+  .fa-border {
+    border: solid 0.08em #eee;
+    border-radius: .1em;
+    padding: .2em .25em .15em; }
+  .fa-pull-left {
+    float: left; }
+  .fa-pull-right {
+    float: right; }
+  .fa.fa-pull-left,
+  .fas.fa-pull-left,
+  .far.fa-pull-left,
+  .fal.fa-pull-left,
+  .fab.fa-pull-left {
+    margin-right: .3em; }
+  .fa.fa-pull-right,
+  .fas.fa-pull-right,
+  .far.fa-pull-right,
+  .fal.fa-pull-right,
+  .fab.fa-pull-right {
+    margin-left: .3em; }
+  .fa-spin {
+    animation: fa-spin 2s infinite linear; }
+  .fa-pulse {
+    animation: fa-spin 1s infinite steps(8); }
+  @keyframes fa-spin {
+    0% {
+      transform: rotate(0deg); }
+    100% {
+      transform: rotate(360deg); } }
+  .fa-rotate-90 {
+    -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=1)";
+    transform: rotate(90deg); }
+  .fa-rotate-180 {
+    -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2)";
+    transform: rotate(180deg); }
+  .fa-rotate-270 {
+    -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=3)";
+    transform: rotate(270deg); }
+  .fa-flip-horizontal {
+    -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1)";
+    transform: scale(-1, 1); }
+  .fa-flip-vertical {
+    -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1)";
+    transform: scale(1, -1); }
+  .fa-flip-both, .fa-flip-horizontal.fa-flip-vertical {
+    -ms-filter: "progid:DXImageTransform.Microsoft.BasicImage(rotation=2, mirror=1)";
+    transform: scale(-1, -1); }
+  :root .fa-rotate-90,
+  :root .fa-rotate-180,
+  :root .fa-rotate-270,
+  :root .fa-flip-horizontal,
+  :root .fa-flip-vertical,
+  :root .fa-flip-both {
+    filter: none; }
+  .fa-stack {
+    display: inline-block;
+    height: 2em;
+    line-height: 2em;
+    position: relative;
+    vertical-align: middle;
+    width: 2.5em; }
+  .fa-stack-1x,
+  .fa-stack-2x {
+    left: 0;
+    position: absolute;
+    text-align: center;
+    width: 100%; }
+  .fa-stack-1x {
+    line-height: inherit; }
+  .fa-stack-2x {
+    font-size: 2em; }
+  .fa-inverse {
+    color: #fff; }
+  /* Font Awesome uses the Unicode Private Use Area (PUA) to ensure screen
+readers do not read off random characters that represent icons */
+  .fa-500px:before {
+    content: "\f26e"; }
+  .fa-accessible-icon:before {
+    content: "\f368"; }
+  .fa-accusoft:before {
+    content: "\f369"; }
+  .fa-acquisitions-incorporated:before {
+    content: "\f6af"; }
+  .fa-ad:before {
+    content: "\f641"; }
+  .fa-address-book:before {
+    content: "\f2b9"; }
+  .fa-address-card:before {
+    content: "\f2bb"; }
+  .fa-adjust:before {
+    content: "\f042"; }
+  .fa-adn:before {
+    content: "\f170"; }
+  .fa-adversal:before {
+    content: "\f36a"; }
+  .fa-affiliatetheme:before {
+    content: "\f36b"; }
+  .fa-air-freshener:before {
+    content: "\f5d0"; }
+  .fa-airbnb:before {
+    content: "\f834"; }
+  .fa-algolia:before {
+    content: "\f36c"; }
+  .fa-align-center:before {
+    content: "\f037"; }
+  .fa-align-justify:before {
+    content: "\f039"; }
+  .fa-align-left:before {
+    content: "\f036"; }
+  .fa-align-right:before {
+    content: "\f038"; }
+  .fa-alipay:before {
+    content: "\f642"; }
+  .fa-allergies:before {
+    content: "\f461"; }
+  .fa-amazon:before {
+    content: "\f270"; }
+  .fa-amazon-pay:before {
+    content: "\f42c"; }
+  .fa-ambulance:before {
+    content: "\f0f9"; }
+  .fa-american-sign-language-interpreting:before {
+    content: "\f2a3"; }
+  .fa-amilia:before {
+    content: "\f36d"; }
+  .fa-anchor:before {
+    content: "\f13d"; }
+  .fa-android:before {
+    content: "\f17b"; }
+  .fa-angellist:before {
+    content: "\f209"; }
+  .fa-angle-double-down:before {
+    content: "\f103"; }
+  .fa-angle-double-left:before {
+    content: "\f100"; }
+  .fa-angle-double-right:before {
+    content: "\f101"; }
+  .fa-angle-double-up:before {
+    content: "\f102"; }
+  .fa-angle-down:before {
+    content: "\f107"; }
+  .fa-angle-left:before {
+    content: "\f104"; }
+  .fa-angle-right:before {
+    content: "\f105"; }
+  .fa-angle-up:before {
+    content: "\f106"; }
+  .fa-angry:before {
+    content: "\f556"; }
+  .fa-angrycreative:before {
+    content: "\f36e"; }
+  .fa-angular:before {
+    content: "\f420"; }
+  .fa-ankh:before {
+    content: "\f644"; }
+  .fa-app-store:before {
+    content: "\f36f"; }
+  .fa-app-store-ios:before {
+    content: "\f370"; }
+  .fa-apper:before {
+    content: "\f371"; }
+  .fa-apple:before {
+    content: "\f179"; }
+  .fa-apple-alt:before {
+    content: "\f5d1"; }
+  .fa-apple-pay:before {
+    content: "\f415"; }
+  .fa-archive:before {
+    content: "\f187"; }
+  .fa-archway:before {
+    content: "\f557"; }
+  .fa-arrow-alt-circle-down:before {
+    content: "\f358"; }
+  .fa-arrow-alt-circle-left:before {
+    content: "\f359"; }
+  .fa-arrow-alt-circle-right:before {
+    content: "\f35a"; }
+  .fa-arrow-alt-circle-up:before {
+    content: "\f35b"; }
+  .fa-arrow-circle-down:before {
+    content: "\f0ab"; }
+  .fa-arrow-circle-left:before {
+    content: "\f0a8"; }
+  .fa-arrow-circle-right:before {
+    content: "\f0a9"; }
+  .fa-arrow-circle-up:before {
+    content: "\f0aa"; }
+  .fa-arrow-down:before {
+    content: "\f063"; }
+  .fa-arrow-left:before {
+    content: "\f060"; }
+  .fa-arrow-right:before {
+    content: "\f061"; }
+  .fa-arrow-up:before {
+    content: "\f062"; }
+  .fa-arrows-alt:before {
+    content: "\f0b2"; }
+  .fa-arrows-alt-h:before {
+    content: "\f337"; }
+  .fa-arrows-alt-v:before {
+    content: "\f338"; }
+  .fa-artstation:before {
+    content: "\f77a"; }
+  .fa-assistive-listening-systems:before {
+    content: "\f2a2"; }
+  .fa-asterisk:before {
+    content: "\f069"; }
+  .fa-asymmetrik:before {
+    content: "\f372"; }
+  .fa-at:before {
+    content: "\f1fa"; }
+  .fa-atlas:before {
+    content: "\f558"; }
+  .fa-atlassian:before {
+    content: "\f77b"; }
+  .fa-atom:before {
+    content: "\f5d2"; }
+  .fa-audible:before {
+    content: "\f373"; }
+  .fa-audio-description:before {
+    content: "\f29e"; }
+  .fa-autoprefixer:before {
+    content: "\f41c"; }
+  .fa-avianex:before {
+    content: "\f374"; }
+  .fa-aviato:before {
+    content: "\f421"; }
+  .fa-award:before {
+    content: "\f559"; }
+  .fa-aws:before {
+    content: "\f375"; }
+  .fa-baby:before {
+    content: "\f77c"; }
+  .fa-baby-carriage:before {
+    content: "\f77d"; }
+  .fa-backspace:before {
+    content: "\f55a"; }
+  .fa-backward:before {
+    content: "\f04a"; }
+  .fa-bacon:before {
+    content: "\f7e5"; }
+  .fa-bacteria:before {
+    content: "\e059"; }
+  .fa-bacterium:before {
+    content: "\e05a"; }
+  .fa-bahai:before {
+    content: "\f666"; }
+  .fa-balance-scale:before {
+    content: "\f24e"; }
+  .fa-balance-scale-left:before {
+    content: "\f515"; }
+  .fa-balance-scale-right:before {
+    content: "\f516"; }
+  .fa-ban:before {
+    content: "\f05e"; }
+  .fa-band-aid:before {
+    content: "\f462"; }
+  .fa-bandcamp:before {
+    content: "\f2d5"; }
+  .fa-barcode:before {
+    content: "\f02a"; }
+  .fa-bars:before {
+    content: "\f0c9"; }
+  .fa-baseball-ball:before {
+    content: "\f433"; }
+  .fa-basketball-ball:before {
+    content: "\f434"; }
+  .fa-bath:before {
+    content: "\f2cd"; }
+  .fa-battery-empty:before {
+    content: "\f244"; }
+  .fa-battery-full:before {
+    content: "\f240"; }
+  .fa-battery-half:before {
+    content: "\f242"; }
+  .fa-battery-quarter:before {
+    content: "\f243"; }
+  .fa-battery-three-quarters:before {
+    content: "\f241"; }
+  .fa-battle-net:before {
+    content: "\f835"; }
+  .fa-bed:before {
+    content: "\f236"; }
+  .fa-beer:before {
+    content: "\f0fc"; }
+  .fa-behance:before {
+    content: "\f1b4"; }
+  .fa-behance-square:before {
+    content: "\f1b5"; }
+  .fa-bell:before {
+    content: "\f0f3"; }
+  .fa-bell-slash:before {
+    content: "\f1f6"; }
+  .fa-bezier-curve:before {
+    content: "\f55b"; }
+  .fa-bible:before {
+    content: "\f647"; }
+  .fa-bicycle:before {
+    content: "\f206"; }
+  .fa-biking:before {
+    content: "\f84a"; }
+  .fa-bimobject:before {
+    content: "\f378"; }
+  .fa-binoculars:before {
+    content: "\f1e5"; }
+  .fa-biohazard:before {
+    content: "\f780"; }
+  .fa-birthday-cake:before {
+    content: "\f1fd"; }
+  .fa-bitbucket:before {
+    content: "\f171"; }
+  .fa-bitcoin:before {
+    content: "\f379"; }
+  .fa-bity:before {
+    content: "\f37a"; }
+  .fa-black-tie:before {
+    content: "\f27e"; }
+  .fa-blackberry:before {
+    content: "\f37b"; }
+  .fa-blender:before {
+    content: "\f517"; }
+  .fa-blender-phone:before {
+    content: "\f6b6"; }
+  .fa-blind:before {
+    content: "\f29d"; }
+  .fa-blog:before {
+    content: "\f781"; }
+  .fa-blogger:before {
+    content: "\f37c"; }
+  .fa-blogger-b:before {
+    content: "\f37d"; }
+  .fa-bluetooth:before {
+    content: "\f293"; }
+  .fa-bluetooth-b:before {
+    content: "\f294"; }
+  .fa-bold:before {
+    content: "\f032"; }
+  .fa-bolt:before {
+    content: "\f0e7"; }
+  .fa-bomb:before {
+    content: "\f1e2"; }
+  .fa-bone:before {
+    content: "\f5d7"; }
+  .fa-bong:before {
+    content: "\f55c"; }
+  .fa-book:before {
+    content: "\f02d"; }
+  .fa-book-dead:before {
+    content: "\f6b7"; }
+  .fa-book-medical:before {
+    content: "\f7e6"; }
+  .fa-book-open:before {
+    content: "\f518"; }
+  .fa-book-reader:before {
+    content: "\f5da"; }
+  .fa-bookmark:before {
+    content: "\f02e"; }
+  .fa-bootstrap:before {
+    content: "\f836"; }
+  .fa-border-all:before {
+    content: "\f84c"; }
+  .fa-border-none:before {
+    content: "\f850"; }
+  .fa-border-style:before {
+    content: "\f853"; }
+  .fa-bowling-ball:before {
+    content: "\f436"; }
+  .fa-box:before {
+    content: "\f466"; }
+  .fa-box-open:before {
+    content: "\f49e"; }
+  .fa-box-tissue:before {
+    content: "\e05b"; }
+  .fa-boxes:before {
+    content: "\f468"; }
+  .fa-braille:before {
+    content: "\f2a1"; }
+  .fa-brain:before {
+    content: "\f5dc"; }
+  .fa-bread-slice:before {
+    content: "\f7ec"; }
+  .fa-briefcase:before {
+    content: "\f0b1"; }
+  .fa-briefcase-medical:before {
+    content: "\f469"; }
+  .fa-broadcast-tower:before {
+    content: "\f519"; }
+  .fa-broom:before {
+    content: "\f51a"; }
+  .fa-brush:before {
+    content: "\f55d"; }
+  .fa-btc:before {
+    content: "\f15a"; }
+  .fa-buffer:before {
+    content: "\f837"; }
+  .fa-bug:before {
+    content: "\f188"; }
+  .fa-building:before {
+    content: "\f1ad"; }
+  .fa-bullhorn:before {
+    content: "\f0a1"; }
+  .fa-bullseye:before {
+    content: "\f140"; }
+  .fa-burn:before {
+    content: "\f46a"; }
+  .fa-buromobelexperte:before {
+    content: "\f37f"; }
+  .fa-bus:before {
+    content: "\f207"; }
+  .fa-bus-alt:before {
+    content: "\f55e"; }
+  .fa-business-time:before {
+    content: "\f64a"; }
+  .fa-buy-n-large:before {
+    content: "\f8a6"; }
+  .fa-buysellads:before {
+    content: "\f20d"; }
+  .fa-calculator:before {
+    content: "\f1ec"; }
+  .fa-calendar:before {
+    content: "\f133"; }
+  .fa-calendar-alt:before {
+    content: "\f073"; }
+  .fa-calendar-check:before {
+    content: "\f274"; }
+  .fa-calendar-day:before {
+    content: "\f783"; }
+  .fa-calendar-minus:before {
+    content: "\f272"; }
+  .fa-calendar-plus:before {
+    content: "\f271"; }
+  .fa-calendar-times:before {
+    content: "\f273"; }
+  .fa-calendar-week:before {
+    content: "\f784"; }
+  .fa-camera:before {
+    content: "\f030"; }
+  .fa-camera-retro:before {
+    content: "\f083"; }
+  .fa-campground:before {
+    content: "\f6bb"; }
+  .fa-canadian-maple-leaf:before {
+    content: "\f785"; }
+  .fa-candy-cane:before {
+    content: "\f786"; }
+  .fa-cannabis:before {
+    content: "\f55f"; }
+  .fa-capsules:before {
+    content: "\f46b"; }
+  .fa-car:before {
+    content: "\f1b9"; }
+  .fa-car-alt:before {
+    content: "\f5de"; }
+  .fa-car-battery:before {
+    content: "\f5df"; }
+  .fa-car-crash:before {
+    content: "\f5e1"; }
+  .fa-car-side:before {
+    content: "\f5e4"; }
+  .fa-caravan:before {
+    content: "\f8ff"; }
+  .fa-caret-down:before {
+    content: "\f0d7"; }
+  .fa-caret-left:before {
+    content: "\f0d9"; }
+  .fa-caret-right:before {
+    content: "\f0da"; }
+  .fa-caret-square-down:before {
+    content: "\f150"; }
+  .fa-caret-square-left:before {
+    content: "\f191"; }
+  .fa-caret-square-right:before {
+    content: "\f152"; }
+  .fa-caret-square-up:before {
+    content: "\f151"; }
+  .fa-caret-up:before {
+    content: "\f0d8"; }
+  .fa-carrot:before {
+    content: "\f787"; }
+  .fa-cart-arrow-down:before {
+    content: "\f218"; }
+  .fa-cart-plus:before {
+    content: "\f217"; }
+  .fa-cash-register:before {
+    content: "\f788"; }
+  .fa-cat:before {
+    content: "\f6be"; }
+  .fa-cc-amazon-pay:before {
+    content: "\f42d"; }
+  .fa-cc-amex:before {
+    content: "\f1f3"; }
+  .fa-cc-apple-pay:before {
+    content: "\f416"; }
+  .fa-cc-diners-club:before {
+    content: "\f24c"; }
+  .fa-cc-discover:before {
+    content: "\f1f2"; }
+  .fa-cc-jcb:before {
+    content: "\f24b"; }
+  .fa-cc-mastercard:before {
+    content: "\f1f1"; }
+  .fa-cc-paypal:before {
+    content: "\f1f4"; }
+  .fa-cc-stripe:before {
+    content: "\f1f5"; }
+  .fa-cc-visa:before {
+    content: "\f1f0"; }
+  .fa-centercode:before {
+    content: "\f380"; }
+  .fa-centos:before {
+    content: "\f789"; }
+  .fa-certificate:before {
+    content: "\f0a3"; }
+  .fa-chair:before {
+    content: "\f6c0"; }
+  .fa-chalkboard:before {
+    content: "\f51b"; }
+  .fa-chalkboard-teacher:before {
+    content: "\f51c"; }
+  .fa-charging-station:before {
+    content: "\f5e7"; }
+  .fa-chart-area:before {
+    content: "\f1fe"; }
+  .fa-chart-bar:before {
+    content: "\f080"; }
+  .fa-chart-line:before {
+    content: "\f201"; }
+  .fa-chart-pie:before {
+    content: "\f200"; }
+  .fa-check:before {
+    content: "\f00c"; }
+  .fa-check-circle:before {
+    content: "\f058"; }
+  .fa-check-double:before {
+    content: "\f560"; }
+  .fa-check-square:before {
+    content: "\f14a"; }
+  .fa-cheese:before {
+    content: "\f7ef"; }
+  .fa-chess:before {
+    content: "\f439"; }
+  .fa-chess-bishop:before {
+    content: "\f43a"; }
+  .fa-chess-board:before {
+    content: "\f43c"; }
+  .fa-chess-king:before {
+    content: "\f43f"; }
+  .fa-chess-knight:before {
+    content: "\f441"; }
+  .fa-chess-pawn:before {
+    content: "\f443"; }
+  .fa-chess-queen:before {
+    content: "\f445"; }
+  .fa-chess-rook:before {
+    content: "\f447"; }
+  .fa-chevron-circle-down:before {
+    content: "\f13a"; }
+  .fa-chevron-circle-left:before {
+    content: "\f137"; }
+  .fa-chevron-circle-right:before {
+    content: "\f138"; }
+  .fa-chevron-circle-up:before {
+    content: "\f139"; }
+  .fa-chevron-down:before {
+    content: "\f078"; }
+  .fa-chevron-left:before {
+    content: "\f053"; }
+  .fa-chevron-right:before {
+    content: "\f054"; }
+  .fa-chevron-up:before {
+    content: "\f077"; }
+  .fa-child:before {
+    content: "\f1ae"; }
+  .fa-chrome:before {
+    content: "\f268"; }
+  .fa-chromecast:before {
+    content: "\f838"; }
+  .fa-church:before {
+    content: "\f51d"; }
+  .fa-circle:before {
+    content: "\f111"; }
+  .fa-circle-notch:before {
+    content: "\f1ce"; }
+  .fa-city:before {
+    content: "\f64f"; }
+  .fa-clinic-medical:before {
+    content: "\f7f2"; }
+  .fa-clipboard:before {
+    content: "\f328"; }
+  .fa-clipboard-check:before {
+    content: "\f46c"; }
+  .fa-clipboard-list:before {
+    content: "\f46d"; }
+  .fa-clock:before {
+    content: "\f017"; }
+  .fa-clone:before {
+    content: "\f24d"; }
+  .fa-closed-captioning:before {
+    content: "\f20a"; }
+  .fa-cloud:before {
+    content: "\f0c2"; }
+  .fa-cloud-download-alt:before {
+    content: "\f381"; }
+  .fa-cloud-meatball:before {
+    content: "\f73b"; }
+  .fa-cloud-moon:before {
+    content: "\f6c3"; }
+  .fa-cloud-moon-rain:before {
+    content: "\f73c"; }
+  .fa-cloud-rain:before {
+    content: "\f73d"; }
+  .fa-cloud-showers-heavy:before {
+    content: "\f740"; }
+  .fa-cloud-sun:before {
+    content: "\f6c4"; }
+  .fa-cloud-sun-rain:before {
+    content: "\f743"; }
+  .fa-cloud-upload-alt:before {
+    content: "\f382"; }
+  .fa-cloudflare:before {
+    content: "\e07d"; }
+  .fa-cloudscale:before {
+    content: "\f383"; }
+  .fa-cloudsmith:before {
+    content: "\f384"; }
+  .fa-cloudversify:before {
+    content: "\f385"; }
+  .fa-cocktail:before {
+    content: "\f561"; }
+  .fa-code:before {
+    content: "\f121"; }
+  .fa-code-branch:before {
+    content: "\f126"; }
+  .fa-codepen:before {
+    content: "\f1cb"; }
+  .fa-codiepie:before {
+    content: "\f284"; }
+  .fa-coffee:before {
+    content: "\f0f4"; }
+  .fa-cog:before {
+    content: "\f013"; }
+  .fa-cogs:before {
+    content: "\f085"; }
+  .fa-coins:before {
+    content: "\f51e"; }
+  .fa-columns:before {
+    content: "\f0db"; }
+  .fa-comment:before {
+    content: "\f075"; }
+  .fa-comment-alt:before {
+    content: "\f27a"; }
+  .fa-comment-dollar:before {
+    content: "\f651"; }
+  .fa-comment-dots:before {
+    content: "\f4ad"; }
+  .fa-comment-medical:before {
+    content: "\f7f5"; }
+  .fa-comment-slash:before {
+    content: "\f4b3"; }
+  .fa-comments:before {
+    content: "\f086"; }
+  .fa-comments-dollar:before {
+    content: "\f653"; }
+  .fa-compact-disc:before {
+    content: "\f51f"; }
+  .fa-compass:before {
+    content: "\f14e"; }
+  .fa-compress:before {
+    content: "\f066"; }
+  .fa-compress-alt:before {
+    content: "\f422"; }
+  .fa-compress-arrows-alt:before {
+    content: "\f78c"; }
+  .fa-concierge-bell:before {
+    content: "\f562"; }
+  .fa-confluence:before {
+    content: "\f78d"; }
+  .fa-connectdevelop:before {
+    content: "\f20e"; }
+  .fa-contao:before {
+    content: "\f26d"; }
+  .fa-cookie:before {
+    content: "\f563"; }
+  .fa-cookie-bite:before {
+    content: "\f564"; }
+  .fa-copy:before {
+    content: "\f0c5"; }
+  .fa-copyright:before {
+    content: "\f1f9"; }
+  .fa-cotton-bureau:before {
+    content: "\f89e"; }
+  .fa-couch:before {
+    content: "\f4b8"; }
+  .fa-cpanel:before {
+    content: "\f388"; }
+  .fa-creative-commons:before {
+    content: "\f25e"; }
+  .fa-creative-commons-by:before {
+    content: "\f4e7"; }
+  .fa-creative-commons-nc:before {
+    content: "\f4e8"; }
+  .fa-creative-commons-nc-eu:before {
+    content: "\f4e9"; }
+  .fa-creative-commons-nc-jp:before {
+    content: "\f4ea"; }
+  .fa-creative-commons-nd:before {
+    content: "\f4eb"; }
+  .fa-creative-commons-pd:before {
+    content: "\f4ec"; }
+  .fa-creative-commons-pd-alt:before {
+    content: "\f4ed"; }
+  .fa-creative-commons-remix:before {
+    content: "\f4ee"; }
+  .fa-creative-commons-sa:before {
+    content: "\f4ef"; }
+  .fa-creative-commons-sampling:before {
+    content: "\f4f0"; }
+  .fa-creative-commons-sampling-plus:before {
+    content: "\f4f1"; }
+  .fa-creative-commons-share:before {
+    content: "\f4f2"; }
+  .fa-creative-commons-zero:before {
+    content: "\f4f3"; }
+  .fa-credit-card:before {
+    content: "\f09d"; }
+  .fa-critical-role:before {
+    content: "\f6c9"; }
+  .fa-crop:before {
+    content: "\f125"; }
+  .fa-crop-alt:before {
+    content: "\f565"; }
+  .fa-cross:before {
+    content: "\f654"; }
+  .fa-crosshairs:before {
+    content: "\f05b"; }
+  .fa-crow:before {
+    content: "\f520"; }
+  .fa-crown:before {
+    content: "\f521"; }
+  .fa-crutch:before {
+    content: "\f7f7"; }
+  .fa-css3:before {
+    content: "\f13c"; }
+  .fa-css3-alt:before {
+    content: "\f38b"; }
+  .fa-cube:before {
+    content: "\f1b2"; }
+  .fa-cubes:before {
+    content: "\f1b3"; }
+  .fa-cut:before {
+    content: "\f0c4"; }
+  .fa-cuttlefish:before {
+    content: "\f38c"; }
+  .fa-d-and-d:before {
+    content: "\f38d"; }
+  .fa-d-and-d-beyond:before {
+    content: "\f6ca"; }
+  .fa-dailymotion:before {
+    content: "\e052"; }
+  .fa-dashcube:before {
+    content: "\f210"; }
+  .fa-database:before {
+    content: "\f1c0"; }
+  .fa-deaf:before {
+    content: "\f2a4"; }
+  .fa-deezer:before {
+    content: "\e077"; }
+  .fa-delicious:before {
+    content: "\f1a5"; }
+  .fa-democrat:before {
+    content: "\f747"; }
+  .fa-deploydog:before {
+    content: "\f38e"; }
+  .fa-deskpro:before {
+    content: "\f38f"; }
+  .fa-desktop:before {
+    content: "\f108"; }
+  .fa-dev:before {
+    content: "\f6cc"; }
+  .fa-deviantart:before {
+    content: "\f1bd"; }
+  .fa-dharmachakra:before {
+    content: "\f655"; }
+  .fa-dhl:before {
+    content: "\f790"; }
+  .fa-diagnoses:before {
+    content: "\f470"; }
+  .fa-diaspora:before {
+    content: "\f791"; }
+  .fa-dice:before {
+    content: "\f522"; }
+  .fa-dice-d20:before {
+    content: "\f6cf"; }
+  .fa-dice-d6:before {
+    content: "\f6d1"; }
+  .fa-dice-five:before {
+    content: "\f523"; }
+  .fa-dice-four:before {
+    content: "\f524"; }
+  .fa-dice-one:before {
+    content: "\f525"; }
+  .fa-dice-six:before {
+    content: "\f526"; }
+  .fa-dice-three:before {
+    content: "\f527"; }
+  .fa-dice-two:before {
+    content: "\f528"; }
+  .fa-digg:before {
+    content: "\f1a6"; }
+  .fa-digital-ocean:before {
+    content: "\f391"; }
+  .fa-digital-tachograph:before {
+    content: "\f566"; }
+  .fa-directions:before {
+    content: "\f5eb"; }
+  .fa-discord:before {
+    content: "\f392"; }
+  .fa-discourse:before {
+    content: "\f393"; }
+  .fa-disease:before {
+    content: "\f7fa"; }
+  .fa-divide:before {
+    content: "\f529"; }
+  .fa-dizzy:before {
+    content: "\f567"; }
+  .fa-dna:before {
+    content: "\f471"; }
+  .fa-dochub:before {
+    content: "\f394"; }
+  .fa-docker:before {
+    content: "\f395"; }
+  .fa-dog:before {
+    content: "\f6d3"; }
+  .fa-dollar-sign:before {
+    content: "\f155"; }
+  .fa-dolly:before {
+    content: "\f472"; }
+  .fa-dolly-flatbed:before {
+    content: "\f474"; }
+  .fa-donate:before {
+    content: "\f4b9"; }
+  .fa-door-closed:before {
+    content: "\f52a"; }
+  .fa-door-open:before {
+    content: "\f52b"; }
+  .fa-dot-circle:before {
+    content: "\f192"; }
+  .fa-dove:before {
+    content: "\f4ba"; }
+  .fa-download:before {
+    content: "\f019"; }
+  .fa-draft2digital:before {
+    content: "\f396"; }
+  .fa-drafting-compass:before {
+    content: "\f568"; }
+  .fa-dragon:before {
+    content: "\f6d5"; }
+  .fa-draw-polygon:before {
+    content: "\f5ee"; }
+  .fa-dribbble:before {
+    content: "\f17d"; }
+  .fa-dribbble-square:before {
+    content: "\f397"; }
+  .fa-dropbox:before {
+    content: "\f16b"; }
+  .fa-drum:before {
+    content: "\f569"; }
+  .fa-drum-steelpan:before {
+    content: "\f56a"; }
+  .fa-drumstick-bite:before {
+    content: "\f6d7"; }
+  .fa-drupal:before {
+    content: "\f1a9"; }
+  .fa-dumbbell:before {
+    content: "\f44b"; }
+  .fa-dumpster:before {
+    content: "\f793"; }
+  .fa-dumpster-fire:before {
+    content: "\f794"; }
+  .fa-dungeon:before {
+    content: "\f6d9"; }
+  .fa-dyalog:before {
+    content: "\f399"; }
+  .fa-earlybirds:before {
+    content: "\f39a"; }
+  .fa-ebay:before {
+    content: "\f4f4"; }
+  .fa-edge:before {
+    content: "\f282"; }
+  .fa-edge-legacy:before {
+    content: "\e078"; }
+  .fa-edit:before {
+    content: "\f044"; }
+  .fa-egg:before {
+    content: "\f7fb"; }
+  .fa-eject:before {
+    content: "\f052"; }
+  .fa-elementor:before {
+    content: "\f430"; }
+  .fa-ellipsis-h:before {
+    content: "\f141"; }
+  .fa-ellipsis-v:before {
+    content: "\f142"; }
+  .fa-ello:before {
+    content: "\f5f1"; }
+  .fa-ember:before {
+    content: "\f423"; }
+  .fa-empire:before {
+    content: "\f1d1"; }
+  .fa-envelope:before {
+    content: "\f0e0"; }
+  .fa-envelope-open:before {
+    content: "\f2b6"; }
+  .fa-envelope-open-text:before {
+    content: "\f658"; }
+  .fa-envelope-square:before {
+    content: "\f199"; }
+  .fa-envira:before {
+    content: "\f299"; }
+  .fa-equals:before {
+    content: "\f52c"; }
+  .fa-eraser:before {
+    content: "\f12d"; }
+  .fa-erlang:before {
+    content: "\f39d"; }
+  .fa-ethereum:before {
+    content: "\f42e"; }
+  .fa-ethernet:before {
+    content: "\f796"; }
+  .fa-etsy:before {
+    content: "\f2d7"; }
+  .fa-euro-sign:before {
+    content: "\f153"; }
+  .fa-evernote:before {
+    content: "\f839"; }
+  .fa-exchange-alt:before {
+    content: "\f362"; }
+  .fa-exclamation:before {
+    content: "\f12a"; }
+  .fa-exclamation-circle:before {
+    content: "\f06a"; }
+  .fa-exclamation-triangle:before {
+    content: "\f071"; }
+  .fa-expand:before {
+    content: "\f065"; }
+  .fa-expand-alt:before {
+    content: "\f424"; }
+  .fa-expand-arrows-alt:before {
+    content: "\f31e"; }
+  .fa-expeditedssl:before {
+    content: "\f23e"; }
+  .fa-external-link-alt:before {
+    content: "\f35d"; }
+  .fa-external-link-square-alt:before {
+    content: "\f360"; }
+  .fa-eye:before {
+    content: "\f06e"; }
+  .fa-eye-dropper:before {
+    content: "\f1fb"; }
+  .fa-eye-slash:before {
+    content: "\f070"; }
+  .fa-facebook:before {
+    content: "\f09a"; }
+  .fa-facebook-f:before {
+    content: "\f39e"; }
+  .fa-facebook-messenger:before {
+    content: "\f39f"; }
+  .fa-facebook-square:before {
+    content: "\f082"; }
+  .fa-fan:before {
+    content: "\f863"; }
+  .fa-fantasy-flight-games:before {
+    content: "\f6dc"; }
+  .fa-fast-backward:before {
+    content: "\f049"; }
+  .fa-fast-forward:before {
+    content: "\f050"; }
+  .fa-faucet:before {
+    content: "\e005"; }
+  .fa-fax:before {
+    content: "\f1ac"; }
+  .fa-feather:before {
+    content: "\f52d"; }
+  .fa-feather-alt:before {
+    content: "\f56b"; }
+  .fa-fedex:before {
+    content: "\f797"; }
+  .fa-fedora:before {
+    content: "\f798"; }
+  .fa-female:before {
+    content: "\f182"; }
+  .fa-fighter-jet:before {
+    content: "\f0fb"; }
+  .fa-figma:before {
+    content: "\f799"; }
+  .fa-file:before {
+    content: "\f15b"; }
+  .fa-file-alt:before {
+    content: "\f15c"; }
+  .fa-file-archive:before {
+    content: "\f1c6"; }
+  .fa-file-audio:before {
+    content: "\f1c7"; }
+  .fa-file-code:before {
+    content: "\f1c9"; }
+  .fa-file-contract:before {
+    content: "\f56c"; }
+  .fa-file-csv:before {
+    content: "\f6dd"; }
+  .fa-file-download:before {
+    content: "\f56d"; }
+  .fa-file-excel:before {
+    content: "\f1c3"; }
+  .fa-file-export:before {
+    content: "\f56e"; }
+  .fa-file-image:before {
+    content: "\f1c5"; }
+  .fa-file-import:before {
+    content: "\f56f"; }
+  .fa-file-invoice:before {
+    content: "\f570"; }
+  .fa-file-invoice-dollar:before {
+    content: "\f571"; }
+  .fa-file-medical:before {
+    content: "\f477"; }
+  .fa-file-medical-alt:before {
+    content: "\f478"; }
+  .fa-file-pdf:before {
+    content: "\f1c1"; }
+  .fa-file-powerpoint:before {
+    content: "\f1c4"; }
+  .fa-file-prescription:before {
+    content: "\f572"; }
+  .fa-file-signature:before {
+    content: "\f573"; }
+  .fa-file-upload:before {
+    content: "\f574"; }
+  .fa-file-video:before {
+    content: "\f1c8"; }
+  .fa-file-word:before {
+    content: "\f1c2"; }
+  .fa-fill:before {
+    content: "\f575"; }
+  .fa-fill-drip:before {
+    content: "\f576"; }
+  .fa-film:before {
+    content: "\f008"; }
+  .fa-filter:before {
+    content: "\f0b0"; }
+  .fa-fingerprint:before {
+    content: "\f577"; }
+  .fa-fire:before {
+    content: "\f06d"; }
+  .fa-fire-alt:before {
+    content: "\f7e4"; }
+  .fa-fire-extinguisher:before {
+    content: "\f134"; }
+  .fa-firefox:before {
+    content: "\f269"; }
+  .fa-firefox-browser:before {
+    content: "\e007"; }
+  .fa-first-aid:before {
+    content: "\f479"; }
+  .fa-first-order:before {
+    content: "\f2b0"; }
+  .fa-first-order-alt:before {
+    content: "\f50a"; }
+  .fa-firstdraft:before {
+    content: "\f3a1"; }
+  .fa-fish:before {
+    content: "\f578"; }
+  .fa-fist-raised:before {
+    content: "\f6de"; }
+  .fa-flag:before {
+    content: "\f024"; }
+  .fa-flag-checkered:before {
+    content: "\f11e"; }
+  .fa-flag-usa:before {
+    content: "\f74d"; }
+  .fa-flask:before {
+    content: "\f0c3"; }
+  .fa-flickr:before {
+    content: "\f16e"; }
+  .fa-flipboard:before {
+    content: "\f44d"; }
+  .fa-flushed:before {
+    content: "\f579"; }
+  .fa-fly:before {
+    content: "\f417"; }
+  .fa-folder:before {
+    content: "\f07b"; }
+  .fa-folder-minus:before {
+    content: "\f65d"; }
+  .fa-folder-open:before {
+    content: "\f07c"; }
+  .fa-folder-plus:before {
+    content: "\f65e"; }
+  .fa-font:before {
+    content: "\f031"; }
+  .fa-font-awesome:before {
+    content: "\f2b4"; }
+  .fa-font-awesome-alt:before {
+    content: "\f35c"; }
+  .fa-font-awesome-flag:before {
+    content: "\f425"; }
+  .fa-font-awesome-logo-full:before {
+    content: "\f4e6"; }
+  .fa-fonticons:before {
+    content: "\f280"; }
+  .fa-fonticons-fi:before {
+    content: "\f3a2"; }
+  .fa-football-ball:before {
+    content: "\f44e"; }
+  .fa-fort-awesome:before {
+    content: "\f286"; }
+  .fa-fort-awesome-alt:before {
+    content: "\f3a3"; }
+  .fa-forumbee:before {
+    content: "\f211"; }
+  .fa-forward:before {
+    content: "\f04e"; }
+  .fa-foursquare:before {
+    content: "\f180"; }
+  .fa-free-code-camp:before {
+    content: "\f2c5"; }
+  .fa-freebsd:before {
+    content: "\f3a4"; }
+  .fa-frog:before {
+    content: "\f52e"; }
+  .fa-frown:before {
+    content: "\f119"; }
+  .fa-frown-open:before {
+    content: "\f57a"; }
+  .fa-fulcrum:before {
+    content: "\f50b"; }
+  .fa-funnel-dollar:before {
+    content: "\f662"; }
+  .fa-futbol:before {
+    content: "\f1e3"; }
+  .fa-galactic-republic:before {
+    content: "\f50c"; }
+  .fa-galactic-senate:before {
+    content: "\f50d"; }
+  .fa-gamepad:before {
+    content: "\f11b"; }
+  .fa-gas-pump:before {
+    content: "\f52f"; }
+  .fa-gavel:before {
+    content: "\f0e3"; }
+  .fa-gem:before {
+    content: "\f3a5"; }
+  .fa-genderless:before {
+    content: "\f22d"; }
+  .fa-get-pocket:before {
+    content: "\f265"; }
+  .fa-gg:before {
+    content: "\f260"; }
+  .fa-gg-circle:before {
+    content: "\f261"; }
+  .fa-ghost:before {
+    content: "\f6e2"; }
+  .fa-gift:before {
+    content: "\f06b"; }
+  .fa-gifts:before {
+    content: "\f79c"; }
+  .fa-git:before {
+    content: "\f1d3"; }
+  .fa-git-alt:before {
+    content: "\f841"; }
+  .fa-git-square:before {
+    content: "\f1d2"; }
+  .fa-github:before {
+    content: "\f09b"; }
+  .fa-github-alt:before {
+    content: "\f113"; }
+  .fa-github-square:before {
+    content: "\f092"; }
+  .fa-gitkraken:before {
+    content: "\f3a6"; }
+  .fa-gitlab:before {
+    content: "\f296"; }
+  .fa-gitter:before {
+    content: "\f426"; }
+  .fa-glass-cheers:before {
+    content: "\f79f"; }
+  .fa-glass-martini:before {
+    content: "\f000"; }
+  .fa-glass-martini-alt:before {
+    content: "\f57b"; }
+  .fa-glass-whiskey:before {
+    content: "\f7a0"; }
+  .fa-glasses:before {
+    content: "\f530"; }
+  .fa-glide:before {
+    content: "\f2a5"; }
+  .fa-glide-g:before {
+    content: "\f2a6"; }
+  .fa-globe:before {
+    content: "\f0ac"; }
+  .fa-globe-africa:before {
+    content: "\f57c"; }
+  .fa-globe-americas:before {
+    content: "\f57d"; }
+  .fa-globe-asia:before {
+    content: "\f57e"; }
+  .fa-globe-europe:before {
+    content: "\f7a2"; }
+  .fa-gofore:before {
+    content: "\f3a7"; }
+  .fa-golf-ball:before {
+    content: "\f450"; }
+  .fa-goodreads:before {
+    content: "\f3a8"; }
+  .fa-goodreads-g:before {
+    content: "\f3a9"; }
+  .fa-google:before {
+    content: "\f1a0"; }
+  .fa-google-drive:before {
+    content: "\f3aa"; }
+  .fa-google-pay:before {
+    content: "\e079"; }
+  .fa-google-play:before {
+    content: "\f3ab"; }
+  .fa-google-plus:before {
+    content: "\f2b3"; }
+  .fa-google-plus-g:before {
+    content: "\f0d5"; }
+  .fa-google-plus-square:before {
+    content: "\f0d4"; }
+  .fa-google-wallet:before {
+    content: "\f1ee"; }
+  .fa-gopuram:before {
+    content: "\f664"; }
+  .fa-graduation-cap:before {
+    content: "\f19d"; }
+  .fa-gratipay:before {
+    content: "\f184"; }
+  .fa-grav:before {
+    content: "\f2d6"; }
+  .fa-greater-than:before {
+    content: "\f531"; }
+  .fa-greater-than-equal:before {
+    content: "\f532"; }
+  .fa-grimace:before {
+    content: "\f57f"; }
+  .fa-grin:before {
+    content: "\f580"; }
+  .fa-grin-alt:before {
+    content: "\f581"; }
+  .fa-grin-beam:before {
+    content: "\f582"; }
+  .fa-grin-beam-sweat:before {
+    content: "\f583"; }
+  .fa-grin-hearts:before {
+    content: "\f584"; }
+  .fa-grin-squint:before {
+    content: "\f585"; }
+  .fa-grin-squint-tears:before {
+    content: "\f586"; }
+  .fa-grin-stars:before {
+    content: "\f587"; }
+  .fa-grin-tears:before {
+    content: "\f588"; }
+  .fa-grin-tongue:before {
+    content: "\f589"; }
+  .fa-grin-tongue-squint:before {
+    content: "\f58a"; }
+  .fa-grin-tongue-wink:before {
+    content: "\f58b"; }
+  .fa-grin-wink:before {
+    content: "\f58c"; }
+  .fa-grip-horizontal:before {
+    content: "\f58d"; }
+  .fa-grip-lines:before {
+    content: "\f7a4"; }
+  .fa-grip-lines-vertical:before {
+    content: "\f7a5"; }
+  .fa-grip-vertical:before {
+    content: "\f58e"; }
+  .fa-gripfire:before {
+    content: "\f3ac"; }
+  .fa-grunt:before {
+    content: "\f3ad"; }
+  .fa-guilded:before {
+    content: "\e07e"; }
+  .fa-guitar:before {
+    content: "\f7a6"; }
+  .fa-gulp:before {
+    content: "\f3ae"; }
+  .fa-h-square:before {
+    content: "\f0fd"; }
+  .fa-hacker-news:before {
+    content: "\f1d4"; }
+  .fa-hacker-news-square:before {
+    content: "\f3af"; }
+  .fa-hackerrank:before {
+    content: "\f5f7"; }
+  .fa-hamburger:before {
+    content: "\f805"; }
+  .fa-hammer:before {
+    content: "\f6e3"; }
+  .fa-hamsa:before {
+    content: "\f665"; }
+  .fa-hand-holding:before {
+    content: "\f4bd"; }
+  .fa-hand-holding-heart:before {
+    content: "\f4be"; }
+  .fa-hand-holding-medical:before {
+    content: "\e05c"; }
+  .fa-hand-holding-usd:before {
+    content: "\f4c0"; }
+  .fa-hand-holding-water:before {
+    content: "\f4c1"; }
+  .fa-hand-lizard:before {
+    content: "\f258"; }
+  .fa-hand-middle-finger:before {
+    content: "\f806"; }
+  .fa-hand-paper:before {
+    content: "\f256"; }
+  .fa-hand-peace:before {
+    content: "\f25b"; }
+  .fa-hand-point-down:before {
+    content: "\f0a7"; }
+  .fa-hand-point-left:before {
+    content: "\f0a5"; }
+  .fa-hand-point-right:before {
+    content: "\f0a4"; }
+  .fa-hand-point-up:before {
+    content: "\f0a6"; }
+  .fa-hand-pointer:before {
+    content: "\f25a"; }
+  .fa-hand-rock:before {
+    content: "\f255"; }
+  .fa-hand-scissors:before {
+    content: "\f257"; }
+  .fa-hand-sparkles:before {
+    content: "\e05d"; }
+  .fa-hand-spock:before {
+    content: "\f259"; }
+  .fa-hands:before {
+    content: "\f4c2"; }
+  .fa-hands-helping:before {
+    content: "\f4c4"; }
+  .fa-hands-wash:before {
+    content: "\e05e"; }
+  .fa-handshake:before {
+    content: "\f2b5"; }
+  .fa-handshake-alt-slash:before {
+    content: "\e05f"; }
+  .fa-handshake-slash:before {
+    content: "\e060"; }
+  .fa-hanukiah:before {
+    content: "\f6e6"; }
+  .fa-hard-hat:before {
+    content: "\f807"; }
+  .fa-hashtag:before {
+    content: "\f292"; }
+  .fa-hat-cowboy:before {
+    content: "\f8c0"; }
+  .fa-hat-cowboy-side:before {
+    content: "\f8c1"; }
+  .fa-hat-wizard:before {
+    content: "\f6e8"; }
+  .fa-hdd:before {
+    content: "\f0a0"; }
+  .fa-head-side-cough:before {
+    content: "\e061"; }
+  .fa-head-side-cough-slash:before {
+    content: "\e062"; }
+  .fa-head-side-mask:before {
+    content: "\e063"; }
+  .fa-head-side-virus:before {
+    content: "\e064"; }
+  .fa-heading:before {
+    content: "\f1dc"; }
+  .fa-headphones:before {
+    content: "\f025"; }
+  .fa-headphones-alt:before {
+    content: "\f58f"; }
+  .fa-headset:before {
+    content: "\f590"; }
+  .fa-heart:before {
+    content: "\f004"; }
+  .fa-heart-broken:before {
+    content: "\f7a9"; }
+  .fa-heartbeat:before {
+    content: "\f21e"; }
+  .fa-helicopter:before {
+    content: "\f533"; }
+  .fa-highlighter:before {
+    content: "\f591"; }
+  .fa-hiking:before {
+    content: "\f6ec"; }
+  .fa-hippo:before {
+    content: "\f6ed"; }
+  .fa-hips:before {
+    content: "\f452"; }
+  .fa-hire-a-helper:before {
+    content: "\f3b0"; }
+  .fa-history:before {
+    content: "\f1da"; }
+  .fa-hive:before {
+    content: "\e07f"; }
+  .fa-hockey-puck:before {
+    content: "\f453"; }
+  .fa-holly-berry:before {
+    content: "\f7aa"; }
+  .fa-home:before {
+    content: "\f015"; }
+  .fa-hooli:before {
+    content: "\f427"; }
+  .fa-hornbill:before {
+    content: "\f592"; }
+  .fa-horse:before {
+    content: "\f6f0"; }
+  .fa-horse-head:before {
+    content: "\f7ab"; }
+  .fa-hospital:before {
+    content: "\f0f8"; }
+  .fa-hospital-alt:before {
+    content: "\f47d"; }
+  .fa-hospital-symbol:before {
+    content: "\f47e"; }
+  .fa-hospital-user:before {
+    content: "\f80d"; }
+  .fa-hot-tub:before {
+    content: "\f593"; }
+  .fa-hotdog:before {
+    content: "\f80f"; }
+  .fa-hotel:before {
+    content: "\f594"; }
+  .fa-hotjar:before {
+    content: "\f3b1"; }
+  .fa-hourglass:before {
+    content: "\f254"; }
+  .fa-hourglass-end:before {
+    content: "\f253"; }
+  .fa-hourglass-half:before {
+    content: "\f252"; }
+  .fa-hourglass-start:before {
+    content: "\f251"; }
+  .fa-house-damage:before {
+    content: "\f6f1"; }
+  .fa-house-user:before {
+    content: "\e065"; }
+  .fa-houzz:before {
+    content: "\f27c"; }
+  .fa-hryvnia:before {
+    content: "\f6f2"; }
+  .fa-html5:before {
+    content: "\f13b"; }
+  .fa-hubspot:before {
+    content: "\f3b2"; }
+  .fa-i-cursor:before {
+    content: "\f246"; }
+  .fa-ice-cream:before {
+    content: "\f810"; }
+  .fa-icicles:before {
+    content: "\f7ad"; }
+  .fa-icons:before {
+    content: "\f86d"; }
+  .fa-id-badge:before {
+    content: "\f2c1"; }
+  .fa-id-card:before {
+    content: "\f2c2"; }
+  .fa-id-card-alt:before {
+    content: "\f47f"; }
+  .fa-ideal:before {
+    content: "\e013"; }
+  .fa-igloo:before {
+    content: "\f7ae"; }
+  .fa-image:before {
+    content: "\f03e"; }
+  .fa-images:before {
+    content: "\f302"; }
+  .fa-imdb:before {
+    content: "\f2d8"; }
+  .fa-inbox:before {
+    content: "\f01c"; }
+  .fa-indent:before {
+    content: "\f03c"; }
+  .fa-industry:before {
+    content: "\f275"; }
+  .fa-infinity:before {
+    content: "\f534"; }
+  .fa-info:before {
+    content: "\f129"; }
+  .fa-info-circle:before {
+    content: "\f05a"; }
+  .fa-innosoft:before {
+    content: "\e080"; }
+  .fa-instagram:before {
+    content: "\f16d"; }
+  .fa-instagram-square:before {
+    content: "\e055"; }
+  .fa-instalod:before {
+    content: "\e081"; }
+  .fa-intercom:before {
+    content: "\f7af"; }
+  .fa-internet-explorer:before {
+    content: "\f26b"; }
+  .fa-invision:before {
+    content: "\f7b0"; }
+  .fa-ioxhost:before {
+    content: "\f208"; }
+  .fa-italic:before {
+    content: "\f033"; }
+  .fa-itch-io:before {
+    content: "\f83a"; }
+  .fa-itunes:before {
+    content: "\f3b4"; }
+  .fa-itunes-note:before {
+    content: "\f3b5"; }
+  .fa-java:before {
+    content: "\f4e4"; }
+  .fa-jedi:before {
+    content: "\f669"; }
+  .fa-jedi-order:before {
+    content: "\f50e"; }
+  .fa-jenkins:before {
+    content: "\f3b6"; }
+  .fa-jira:before {
+    content: "\f7b1"; }
+  .fa-joget:before {
+    content: "\f3b7"; }
+  .fa-joint:before {
+    content: "\f595"; }
+  .fa-joomla:before {
+    content: "\f1aa"; }
+  .fa-journal-whills:before {
+    content: "\f66a"; }
+  .fa-js:before {
+    content: "\f3b8"; }
+  .fa-js-square:before {
+    content: "\f3b9"; }
+  .fa-jsfiddle:before {
+    content: "\f1cc"; }
+  .fa-kaaba:before {
+    content: "\f66b"; }
+  .fa-kaggle:before {
+    content: "\f5fa"; }
+  .fa-key:before {
+    content: "\f084"; }
+  .fa-keybase:before {
+    content: "\f4f5"; }
+  .fa-keyboard:before {
+    content: "\f11c"; }
+  .fa-keycdn:before {
+    content: "\f3ba"; }
+  .fa-khanda:before {
+    content: "\f66d"; }
+  .fa-kickstarter:before {
+    content: "\f3bb"; }
+  .fa-kickstarter-k:before {
+    content: "\f3bc"; }
+  .fa-kiss:before {
+    content: "\f596"; }
+  .fa-kiss-beam:before {
+    content: "\f597"; }
+  .fa-kiss-wink-heart:before {
+    content: "\f598"; }
+  .fa-kiwi-bird:before {
+    content: "\f535"; }
+  .fa-korvue:before {
+    content: "\f42f"; }
+  .fa-landmark:before {
+    content: "\f66f"; }
+  .fa-language:before {
+    content: "\f1ab"; }
+  .fa-laptop:before {
+    content: "\f109"; }
+  .fa-laptop-code:before {
+    content: "\f5fc"; }
+  .fa-laptop-house:before {
+    content: "\e066"; }
+  .fa-laptop-medical:before {
+    content: "\f812"; }
+  .fa-laravel:before {
+    content: "\f3bd"; }
+  .fa-lastfm:before {
+    content: "\f202"; }
+  .fa-lastfm-square:before {
+    content: "\f203"; }
+  .fa-laugh:before {
+    content: "\f599"; }
+  .fa-laugh-beam:before {
+    content: "\f59a"; }
+  .fa-laugh-squint:before {
+    content: "\f59b"; }
+  .fa-laugh-wink:before {
+    content: "\f59c"; }
+  .fa-layer-group:before {
+    content: "\f5fd"; }
+  .fa-leaf:before {
+    content: "\f06c"; }
+  .fa-leanpub:before {
+    content: "\f212"; }
+  .fa-lemon:before {
+    content: "\f094"; }
+  .fa-less:before {
+    content: "\f41d"; }
+  .fa-less-than:before {
+    content: "\f536"; }
+  .fa-less-than-equal:before {
+    content: "\f537"; }
+  .fa-level-down-alt:before {
+    content: "\f3be"; }
+  .fa-level-up-alt:before {
+    content: "\f3bf"; }
+  .fa-life-ring:before {
+    content: "\f1cd"; }
+  .fa-lightbulb:before {
+    content: "\f0eb"; }
+  .fa-line:before {
+    content: "\f3c0"; }
+  .fa-link:before {
+    content: "\f0c1"; }
+  .fa-linkedin:before {
+    content: "\f08c"; }
+  .fa-linkedin-in:before {
+    content: "\f0e1"; }
+  .fa-linode:before {
+    content: "\f2b8"; }
+  .fa-linux:before {
+    content: "\f17c"; }
+  .fa-lira-sign:before {
+    content: "\f195"; }
+  .fa-list:before {
+    content: "\f03a"; }
+  .fa-list-alt:before {
+    content: "\f022"; }
+  .fa-list-ol:before {
+    content: "\f0cb"; }
+  .fa-list-ul:before {
+    content: "\f0ca"; }
+  .fa-location-arrow:before {
+    content: "\f124"; }
+  .fa-lock:before {
+    content: "\f023"; }
+  .fa-lock-open:before {
+    content: "\f3c1"; }
+  .fa-long-arrow-alt-down:before {
+    content: "\f309"; }
+  .fa-long-arrow-alt-left:before {
+    content: "\f30a"; }
+  .fa-long-arrow-alt-right:before {
+    content: "\f30b"; }
+  .fa-long-arrow-alt-up:before {
+    content: "\f30c"; }
+  .fa-low-vision:before {
+    content: "\f2a8"; }
+  .fa-luggage-cart:before {
+    content: "\f59d"; }
+  .fa-lungs:before {
+    content: "\f604"; }
+  .fa-lungs-virus:before {
+    content: "\e067"; }
+  .fa-lyft:before {
+    content: "\f3c3"; }
+  .fa-magento:before {
+    content: "\f3c4"; }
+  .fa-magic:before {
+    content: "\f0d0"; }
+  .fa-magnet:before {
+    content: "\f076"; }
+  .fa-mail-bulk:before {
+    content: "\f674"; }
+  .fa-mailchimp:before {
+    content: "\f59e"; }
+  .fa-male:before {
+    content: "\f183"; }
+  .fa-mandalorian:before {
+    content: "\f50f"; }
+  .fa-map:before {
+    content: "\f279"; }
+  .fa-map-marked:before {
+    content: "\f59f"; }
+  .fa-map-marked-alt:before {
+    content: "\f5a0"; }
+  .fa-map-marker:before {
+    content: "\f041"; }
+  .fa-map-marker-alt:before {
+    content: "\f3c5"; }
+  .fa-map-pin:before {
+    content: "\f276"; }
+  .fa-map-signs:before {
+    content: "\f277"; }
+  .fa-markdown:before {
+    content: "\f60f"; }
+  .fa-marker:before {
+    content: "\f5a1"; }
+  .fa-mars:before {
+    content: "\f222"; }
+  .fa-mars-double:before {
+    content: "\f227"; }
+  .fa-mars-stroke:before {
+    content: "\f229"; }
+  .fa-mars-stroke-h:before {
+    content: "\f22b"; }
+  .fa-mars-stroke-v:before {
+    content: "\f22a"; }
+  .fa-mask:before {
+    content: "\f6fa"; }
+  .fa-mastodon:before {
+    content: "\f4f6"; }
+  .fa-maxcdn:before {
+    content: "\f136"; }
+  .fa-mdb:before {
+    content: "\f8ca"; }
+  .fa-medal:before {
+    content: "\f5a2"; }
+  .fa-medapps:before {
+    content: "\f3c6"; }
+  .fa-medium:before {
+    content: "\f23a"; }
+  .fa-medium-m:before {
+    content: "\f3c7"; }
+  .fa-medkit:before {
+    content: "\f0fa"; }
+  .fa-medrt:before {
+    content: "\f3c8"; }
+  .fa-meetup:before {
+    content: "\f2e0"; }
+  .fa-megaport:before {
+    content: "\f5a3"; }
+  .fa-meh:before {
+    content: "\f11a"; }
+  .fa-meh-blank:before {
+    content: "\f5a4"; }
+  .fa-meh-rolling-eyes:before {
+    content: "\f5a5"; }
+  .fa-memory:before {
+    content: "\f538"; }
+  .fa-mendeley:before {
+    content: "\f7b3"; }
+  .fa-menorah:before {
+    content: "\f676"; }
+  .fa-mercury:before {
+    content: "\f223"; }
+  .fa-meteor:before {
+    content: "\f753"; }
+  .fa-microblog:before {
+    content: "\e01a"; }
+  .fa-microchip:before {
+    content: "\f2db"; }
+  .fa-microphone:before {
+    content: "\f130"; }
+  .fa-microphone-alt:before {
+    content: "\f3c9"; }
+  .fa-microphone-alt-slash:before {
+    content: "\f539"; }
+  .fa-microphone-slash:before {
+    content: "\f131"; }
+  .fa-microscope:before {
+    content: "\f610"; }
+  .fa-microsoft:before {
+    content: "\f3ca"; }
+  .fa-minus:before {
+    content: "\f068"; }
+  .fa-minus-circle:before {
+    content: "\f056"; }
+  .fa-minus-square:before {
+    content: "\f146"; }
+  .fa-mitten:before {
+    content: "\f7b5"; }
+  .fa-mix:before {
+    content: "\f3cb"; }
+  .fa-mixcloud:before {
+    content: "\f289"; }
+  .fa-mixer:before {
+    content: "\e056"; }
+  .fa-mizuni:before {
+    content: "\f3cc"; }
+  .fa-mobile:before {
+    content: "\f10b"; }
+  .fa-mobile-alt:before {
+    content: "\f3cd"; }
+  .fa-modx:before {
+    content: "\f285"; }
+  .fa-monero:before {
+    content: "\f3d0"; }
+  .fa-money-bill:before {
+    content: "\f0d6"; }
+  .fa-money-bill-alt:before {
+    content: "\f3d1"; }
+  .fa-money-bill-wave:before {
+    content: "\f53a"; }
+  .fa-money-bill-wave-alt:before {
+    content: "\f53b"; }
+  .fa-money-check:before {
+    content: "\f53c"; }
+  .fa-money-check-alt:before {
+    content: "\f53d"; }
+  .fa-monument:before {
+    content: "\f5a6"; }
+  .fa-moon:before {
+    content: "\f186"; }
+  .fa-mortar-pestle:before {
+    content: "\f5a7"; }
+  .fa-mosque:before {
+    content: "\f678"; }
+  .fa-motorcycle:before {
+    content: "\f21c"; }
+  .fa-mountain:before {
+    content: "\f6fc"; }
+  .fa-mouse:before {
+    content: "\f8cc"; }
+  .fa-mouse-pointer:before {
+    content: "\f245"; }
+  .fa-mug-hot:before {
+    content: "\f7b6"; }
+  .fa-music:before {
+    content: "\f001"; }
+  .fa-napster:before {
+    content: "\f3d2"; }
+  .fa-neos:before {
+    content: "\f612"; }
+  .fa-network-wired:before {
+    content: "\f6ff"; }
+  .fa-neuter:before {
+    content: "\f22c"; }
+  .fa-newspaper:before {
+    content: "\f1ea"; }
+  .fa-nimblr:before {
+    content: "\f5a8"; }
+  .fa-node:before {
+    content: "\f419"; }
+  .fa-node-js:before {
+    content: "\f3d3"; }
+  .fa-not-equal:before {
+    content: "\f53e"; }
+  .fa-notes-medical:before {
+    content: "\f481"; }
+  .fa-npm:before {
+    content: "\f3d4"; }
+  .fa-ns8:before {
+    content: "\f3d5"; }
+  .fa-nutritionix:before {
+    content: "\f3d6"; }
+  .fa-object-group:before {
+    content: "\f247"; }
+  .fa-object-ungroup:before {
+    content: "\f248"; }
+  .fa-octopus-deploy:before {
+    content: "\e082"; }
+  .fa-odnoklassniki:before {
+    content: "\f263"; }
+  .fa-odnoklassniki-square:before {
+    content: "\f264"; }
+  .fa-oil-can:before {
+    content: "\f613"; }
+  .fa-old-republic:before {
+    content: "\f510"; }
+  .fa-om:before {
+    content: "\f679"; }
+  .fa-opencart:before {
+    content: "\f23d"; }
+  .fa-openid:before {
+    content: "\f19b"; }
+  .fa-opera:before {
+    content: "\f26a"; }
+  .fa-optin-monster:before {
+    content: "\f23c"; }
+  .fa-orcid:before {
+    content: "\f8d2"; }
+  .fa-osi:before {
+    content: "\f41a"; }
+  .fa-otter:before {
+    content: "\f700"; }
+  .fa-outdent:before {
+    content: "\f03b"; }
+  .fa-page4:before {
+    content: "\f3d7"; }
+  .fa-pagelines:before {
+    content: "\f18c"; }
+  .fa-pager:before {
+    content: "\f815"; }
+  .fa-paint-brush:before {
+    content: "\f1fc"; }
+  .fa-paint-roller:before {
+    content: "\f5aa"; }
+  .fa-palette:before {
+    content: "\f53f"; }
+  .fa-palfed:before {
+    content: "\f3d8"; }
+  .fa-pallet:before {
+    content: "\f482"; }
+  .fa-paper-plane:before {
+    content: "\f1d8"; }
+  .fa-paperclip:before {
+    content: "\f0c6"; }
+  .fa-parachute-box:before {
+    content: "\f4cd"; }
+  .fa-paragraph:before {
+    content: "\f1dd"; }
+  .fa-parking:before {
+    content: "\f540"; }
+  .fa-passport:before {
+    content: "\f5ab"; }
+  .fa-pastafarianism:before {
+    content: "\f67b"; }
+  .fa-paste:before {
+    content: "\f0ea"; }
+  .fa-patreon:before {
+    content: "\f3d9"; }
+  .fa-pause:before {
+    content: "\f04c"; }
+  .fa-pause-circle:before {
+    content: "\f28b"; }
+  .fa-paw:before {
+    content: "\f1b0"; }
+  .fa-paypal:before {
+    content: "\f1ed"; }
+  .fa-peace:before {
+    content: "\f67c"; }
+  .fa-pen:before {
+    content: "\f304"; }
+  .fa-pen-alt:before {
+    content: "\f305"; }
+  .fa-pen-fancy:before {
+    content: "\f5ac"; }
+  .fa-pen-nib:before {
+    content: "\f5ad"; }
+  .fa-pen-square:before {
+    content: "\f14b"; }
+  .fa-pencil-alt:before {
+    content: "\f303"; }
+  .fa-pencil-ruler:before {
+    content: "\f5ae"; }
+  .fa-penny-arcade:before {
+    content: "\f704"; }
+  .fa-people-arrows:before {
+    content: "\e068"; }
+  .fa-people-carry:before {
+    content: "\f4ce"; }
+  .fa-pepper-hot:before {
+    content: "\f816"; }
+  .fa-perbyte:before {
+    content: "\e083"; }
+  .fa-percent:before {
+    content: "\f295"; }
+  .fa-percentage:before {
+    content: "\f541"; }
+  .fa-periscope:before {
+    content: "\f3da"; }
+  .fa-person-booth:before {
+    content: "\f756"; }
+  .fa-phabricator:before {
+    content: "\f3db"; }
+  .fa-phoenix-framework:before {
+    content: "\f3dc"; }
+  .fa-phoenix-squadron:before {
+    content: "\f511"; }
+  .fa-phone:before {
+    content: "\f095"; }
+  .fa-phone-alt:before {
+    content: "\f879"; }
+  .fa-phone-slash:before {
+    content: "\f3dd"; }
+  .fa-phone-square:before {
+    content: "\f098"; }
+  .fa-phone-square-alt:before {
+    content: "\f87b"; }
+  .fa-phone-volume:before {
+    content: "\f2a0"; }
+  .fa-photo-video:before {
+    content: "\f87c"; }
+  .fa-php:before {
+    content: "\f457"; }
+  .fa-pied-piper:before {
+    content: "\f2ae"; }
+  .fa-pied-piper-alt:before {
+    content: "\f1a8"; }
+  .fa-pied-piper-hat:before {
+    content: "\f4e5"; }
+  .fa-pied-piper-pp:before {
+    content: "\f1a7"; }
+  .fa-pied-piper-square:before {
+    content: "\e01e"; }
+  .fa-piggy-bank:before {
+    content: "\f4d3"; }
+  .fa-pills:before {
+    content: "\f484"; }
+  .fa-pinterest:before {
+    content: "\f0d2"; }
+  .fa-pinterest-p:before {
+    content: "\f231"; }
+  .fa-pinterest-square:before {
+    content: "\f0d3"; }
+  .fa-pizza-slice:before {
+    content: "\f818"; }
+  .fa-place-of-worship:before {
+    content: "\f67f"; }
+  .fa-plane:before {
+    content: "\f072"; }
+  .fa-plane-arrival:before {
+    content: "\f5af"; }
+  .fa-plane-departure:before {
+    content: "\f5b0"; }
+  .fa-plane-slash:before {
+    content: "\e069"; }
+  .fa-play:before {
+    content: "\f04b"; }
+  .fa-play-circle:before {
+    content: "\f144"; }
+  .fa-playstation:before {
+    content: "\f3df"; }
+  .fa-plug:before {
+    content: "\f1e6"; }
+  .fa-plus:before {
+    content: "\f067"; }
+  .fa-plus-circle:before {
+    content: "\f055"; }
+  .fa-plus-square:before {
+    content: "\f0fe"; }
+  .fa-podcast:before {
+    content: "\f2ce"; }
+  .fa-poll:before {
+    content: "\f681"; }
+  .fa-poll-h:before {
+    content: "\f682"; }
+  .fa-poo:before {
+    content: "\f2fe"; }
+  .fa-poo-storm:before {
+    content: "\f75a"; }
+  .fa-poop:before {
+    content: "\f619"; }
+  .fa-portrait:before {
+    content: "\f3e0"; }
+  .fa-pound-sign:before {
+    content: "\f154"; }
+  .fa-power-off:before {
+    content: "\f011"; }
+  .fa-pray:before {
+    content: "\f683"; }
+  .fa-praying-hands:before {
+    content: "\f684"; }
+  .fa-prescription:before {
+    content: "\f5b1"; }
+  .fa-prescription-bottle:before {
+    content: "\f485"; }
+  .fa-prescription-bottle-alt:before {
+    content: "\f486"; }
+  .fa-print:before {
+    content: "\f02f"; }
+  .fa-procedures:before {
+    content: "\f487"; }
+  .fa-product-hunt:before {
+    content: "\f288"; }
+  .fa-project-diagram:before {
+    content: "\f542"; }
+  .fa-pump-medical:before {
+    content: "\e06a"; }
+  .fa-pump-soap:before {
+    content: "\e06b"; }
+  .fa-pushed:before {
+    content: "\f3e1"; }
+  .fa-puzzle-piece:before {
+    content: "\f12e"; }
+  .fa-python:before {
+    content: "\f3e2"; }
+  .fa-qq:before {
+    content: "\f1d6"; }
+  .fa-qrcode:before {
+    content: "\f029"; }
+  .fa-question:before {
+    content: "\f128"; }
+  .fa-question-circle:before {
+    content: "\f059"; }
+  .fa-quidditch:before {
+    content: "\f458"; }
+  .fa-quinscape:before {
+    content: "\f459"; }
+  .fa-quora:before {
+    content: "\f2c4"; }
+  .fa-quote-left:before {
+    content: "\f10d"; }
+  .fa-quote-right:before {
+    content: "\f10e"; }
+  .fa-quran:before {
+    content: "\f687"; }
+  .fa-r-project:before {
+    content: "\f4f7"; }
+  .fa-radiation:before {
+    content: "\f7b9"; }
+  .fa-radiation-alt:before {
+    content: "\f7ba"; }
+  .fa-rainbow:before {
+    content: "\f75b"; }
+  .fa-random:before {
+    content: "\f074"; }
+  .fa-raspberry-pi:before {
+    content: "\f7bb"; }
+  .fa-ravelry:before {
+    content: "\f2d9"; }
+  .fa-react:before {
+    content: "\f41b"; }
+  .fa-reacteurope:before {
+    content: "\f75d"; }
+  .fa-readme:before {
+    content: "\f4d5"; }
+  .fa-rebel:before {
+    content: "\f1d0"; }
+  .fa-receipt:before {
+    content: "\f543"; }
+  .fa-record-vinyl:before {
+    content: "\f8d9"; }
+  .fa-recycle:before {
+    content: "\f1b8"; }
+  .fa-red-river:before {
+    content: "\f3e3"; }
+  .fa-reddit:before {
+    content: "\f1a1"; }
+  .fa-reddit-alien:before {
+    content: "\f281"; }
+  .fa-reddit-square:before {
+    content: "\f1a2"; }
+  .fa-redhat:before {
+    content: "\f7bc"; }
+  .fa-redo:before {
+    content: "\f01e"; }
+  .fa-redo-alt:before {
+    content: "\f2f9"; }
+  .fa-registered:before {
+    content: "\f25d"; }
+  .fa-remove-format:before {
+    content: "\f87d"; }
+  .fa-renren:before {
+    content: "\f18b"; }
+  .fa-reply:before {
+    content: "\f3e5"; }
+  .fa-reply-all:before {
+    content: "\f122"; }
+  .fa-replyd:before {
+    content: "\f3e6"; }
+  .fa-republican:before {
+    content: "\f75e"; }
+  .fa-researchgate:before {
+    content: "\f4f8"; }
+  .fa-resolving:before {
+    content: "\f3e7"; }
+  .fa-restroom:before {
+    content: "\f7bd"; }
+  .fa-retweet:before {
+    content: "\f079"; }
+  .fa-rev:before {
+    content: "\f5b2"; }
+  .fa-ribbon:before {
+    content: "\f4d6"; }
+  .fa-ring:before {
+    content: "\f70b"; }
+  .fa-road:before {
+    content: "\f018"; }
+  .fa-robot:before {
+    content: "\f544"; }
+  .fa-rocket:before {
+    content: "\f135"; }
+  .fa-rocketchat:before {
+    content: "\f3e8"; }
+  .fa-rockrms:before {
+    content: "\f3e9"; }
+  .fa-route:before {
+    content: "\f4d7"; }
+  .fa-rss:before {
+    content: "\f09e"; }
+  .fa-rss-square:before {
+    content: "\f143"; }
+  .fa-ruble-sign:before {
+    content: "\f158"; }
+  .fa-ruler:before {
+    content: "\f545"; }
+  .fa-ruler-combined:before {
+    content: "\f546"; }
+  .fa-ruler-horizontal:before {
+    content: "\f547"; }
+  .fa-ruler-vertical:before {
+    content: "\f548"; }
+  .fa-running:before {
+    content: "\f70c"; }
+  .fa-rupee-sign:before {
+    content: "\f156"; }
+  .fa-rust:before {
+    content: "\e07a"; }
+  .fa-sad-cry:before {
+    content: "\f5b3"; }
+  .fa-sad-tear:before {
+    content: "\f5b4"; }
+  .fa-safari:before {
+    content: "\f267"; }
+  .fa-salesforce:before {
+    content: "\f83b"; }
+  .fa-sass:before {
+    content: "\f41e"; }
+  .fa-satellite:before {
+    content: "\f7bf"; }
+  .fa-satellite-dish:before {
+    content: "\f7c0"; }
+  .fa-save:before {
+    content: "\f0c7"; }
+  .fa-schlix:before {
+    content: "\f3ea"; }
+  .fa-school:before {
+    content: "\f549"; }
+  .fa-screwdriver:before {
+    content: "\f54a"; }
+  .fa-scribd:before {
+    content: "\f28a"; }
+  .fa-scroll:before {
+    content: "\f70e"; }
+  .fa-sd-card:before {
+    content: "\f7c2"; }
+  .fa-search:before {
+    content: "\f002"; }
+  .fa-search-dollar:before {
+    content: "\f688"; }
+  .fa-search-location:before {
+    content: "\f689"; }
+  .fa-search-minus:before {
+    content: "\f010"; }
+  .fa-search-plus:before {
+    content: "\f00e"; }
+  .fa-searchengin:before {
+    content: "\f3eb"; }
+  .fa-seedling:before {
+    content: "\f4d8"; }
+  .fa-sellcast:before {
+    content: "\f2da"; }
+  .fa-sellsy:before {
+    content: "\f213"; }
+  .fa-server:before {
+    content: "\f233"; }
+  .fa-servicestack:before {
+    content: "\f3ec"; }
+  .fa-shapes:before {
+    content: "\f61f"; }
+  .fa-share:before {
+    content: "\f064"; }
+  .fa-share-alt:before {
+    content: "\f1e0"; }
+  .fa-share-alt-square:before {
+    content: "\f1e1"; }
+  .fa-share-square:before {
+    content: "\f14d"; }
+  .fa-shekel-sign:before {
+    content: "\f20b"; }
+  .fa-shield-alt:before {
+    content: "\f3ed"; }
+  .fa-shield-virus:before {
+    content: "\e06c"; }
+  .fa-ship:before {
+    content: "\f21a"; }
+  .fa-shipping-fast:before {
+    content: "\f48b"; }
+  .fa-shirtsinbulk:before {
+    content: "\f214"; }
+  .fa-shoe-prints:before {
+    content: "\f54b"; }
+  .fa-shopify:before {
+    content: "\e057"; }
+  .fa-shopping-bag:before {
+    content: "\f290"; }
+  .fa-shopping-basket:before {
+    content: "\f291"; }
+  .fa-shopping-cart:before {
+    content: "\f07a"; }
+  .fa-shopware:before {
+    content: "\f5b5"; }
+  .fa-shower:before {
+    content: "\f2cc"; }
+  .fa-shuttle-van:before {
+    content: "\f5b6"; }
+  .fa-sign:before {
+    content: "\f4d9"; }
+  .fa-sign-in-alt:before {
+    content: "\f2f6"; }
+  .fa-sign-language:before {
+    content: "\f2a7"; }
+  .fa-sign-out-alt:before {
+    content: "\f2f5"; }
+  .fa-signal:before {
+    content: "\f012"; }
+  .fa-signature:before {
+    content: "\f5b7"; }
+  .fa-sim-card:before {
+    content: "\f7c4"; }
+  .fa-simplybuilt:before {
+    content: "\f215"; }
+  .fa-sink:before {
+    content: "\e06d"; }
+  .fa-sistrix:before {
+    content: "\f3ee"; }
+  .fa-sitemap:before {
+    content: "\f0e8"; }
+  .fa-sith:before {
+    content: "\f512"; }
+  .fa-skating:before {
+    content: "\f7c5"; }
+  .fa-sketch:before {
+    content: "\f7c6"; }
+  .fa-skiing:before {
+    content: "\f7c9"; }
+  .fa-skiing-nordic:before {
+    content: "\f7ca"; }
+  .fa-skull:before {
+    content: "\f54c"; }
+  .fa-skull-crossbones:before {
+    content: "\f714"; }
+  .fa-skyatlas:before {
+    content: "\f216"; }
+  .fa-skype:before {
+    content: "\f17e"; }
+  .fa-slack:before {
+    content: "\f198"; }
+  .fa-slack-hash:before {
+    content: "\f3ef"; }
+  .fa-slash:before {
+    content: "\f715"; }
+  .fa-sleigh:before {
+    content: "\f7cc"; }
+  .fa-sliders-h:before {
+    content: "\f1de"; }
+  .fa-slideshare:before {
+    content: "\f1e7"; }
+  .fa-smile:before {
+    content: "\f118"; }
+  .fa-smile-beam:before {
+    content: "\f5b8"; }
+  .fa-smile-wink:before {
+    content: "\f4da"; }
+  .fa-smog:before {
+    content: "\f75f"; }
+  .fa-smoking:before {
+    content: "\f48d"; }
+  .fa-smoking-ban:before {
+    content: "\f54d"; }
+  .fa-sms:before {
+    content: "\f7cd"; }
+  .fa-snapchat:before {
+    content: "\f2ab"; }
+  .fa-snapchat-ghost:before {
+    content: "\f2ac"; }
+  .fa-snapchat-square:before {
+    content: "\f2ad"; }
+  .fa-snowboarding:before {
+    content: "\f7ce"; }
+  .fa-snowflake:before {
+    content: "\f2dc"; }
+  .fa-snowman:before {
+    content: "\f7d0"; }
+  .fa-snowplow:before {
+    content: "\f7d2"; }
+  .fa-soap:before {
+    content: "\e06e"; }
+  .fa-socks:before {
+    content: "\f696"; }
+  .fa-solar-panel:before {
+    content: "\f5ba"; }
+  .fa-sort:before {
+    content: "\f0dc"; }
+  .fa-sort-alpha-down:before {
+    content: "\f15d"; }
+  .fa-sort-alpha-down-alt:before {
+    content: "\f881"; }
+  .fa-sort-alpha-up:before {
+    content: "\f15e"; }
+  .fa-sort-alpha-up-alt:before {
+    content: "\f882"; }
+  .fa-sort-amount-down:before {
+    content: "\f160"; }
+  .fa-sort-amount-down-alt:before {
+    content: "\f884"; }
+  .fa-sort-amount-up:before {
+    content: "\f161"; }
+  .fa-sort-amount-up-alt:before {
+    content: "\f885"; }
+  .fa-sort-down:before {
+    content: "\f0dd"; }
+  .fa-sort-numeric-down:before {
+    content: "\f162"; }
+  .fa-sort-numeric-down-alt:before {
+    content: "\f886"; }
+  .fa-sort-numeric-up:before {
+    content: "\f163"; }
+  .fa-sort-numeric-up-alt:before {
+    content: "\f887"; }
+  .fa-sort-up:before {
+    content: "\f0de"; }
+  .fa-soundcloud:before {
+    content: "\f1be"; }
+  .fa-sourcetree:before {
+    content: "\f7d3"; }
+  .fa-spa:before {
+    content: "\f5bb"; }
+  .fa-space-shuttle:before {
+    content: "\f197"; }
+  .fa-speakap:before {
+    content: "\f3f3"; }
+  .fa-speaker-deck:before {
+    content: "\f83c"; }
+  .fa-spell-check:before {
+    content: "\f891"; }
+  .fa-spider:before {
+    content: "\f717"; }
+  .fa-spinner:before {
+    content: "\f110"; }
+  .fa-splotch:before {
+    content: "\f5bc"; }
+  .fa-spotify:before {
+    content: "\f1bc"; }
+  .fa-spray-can:before {
+    content: "\f5bd"; }
+  .fa-square:before {
+    content: "\f0c8"; }
+  .fa-square-full:before {
+    content: "\f45c"; }
+  .fa-square-root-alt:before {
+    content: "\f698"; }
+  .fa-squarespace:before {
+    content: "\f5be"; }
+  .fa-stack-exchange:before {
+    content: "\f18d"; }
+  .fa-stack-overflow:before {
+    content: "\f16c"; }
+  .fa-stackpath:before {
+    content: "\f842"; }
+  .fa-stamp:before {
+    content: "\f5bf"; }
+  .fa-star:before {
+    content: "\f005"; }
+  .fa-star-and-crescent:before {
+    content: "\f699"; }
+  .fa-star-half:before {
+    content: "\f089"; }
+  .fa-star-half-alt:before {
+    content: "\f5c0"; }
+  .fa-star-of-david:before {
+    content: "\f69a"; }
+  .fa-star-of-life:before {
+    content: "\f621"; }
+  .fa-staylinked:before {
+    content: "\f3f5"; }
+  .fa-steam:before {
+    content: "\f1b6"; }
+  .fa-steam-square:before {
+    content: "\f1b7"; }
+  .fa-steam-symbol:before {
+    content: "\f3f6"; }
+  .fa-step-backward:before {
+    content: "\f048"; }
+  .fa-step-forward:before {
+    content: "\f051"; }
+  .fa-stethoscope:before {
+    content: "\f0f1"; }
+  .fa-sticker-mule:before {
+    content: "\f3f7"; }
+  .fa-sticky-note:before {
+    content: "\f249"; }
+  .fa-stop:before {
+    content: "\f04d"; }
+  .fa-stop-circle:before {
+    content: "\f28d"; }
+  .fa-stopwatch:before {
+    content: "\f2f2"; }
+  .fa-stopwatch-20:before {
+    content: "\e06f"; }
+  .fa-store:before {
+    content: "\f54e"; }
+  .fa-store-alt:before {
+    content: "\f54f"; }
+  .fa-store-alt-slash:before {
+    content: "\e070"; }
+  .fa-store-slash:before {
+    content: "\e071"; }
+  .fa-strava:before {
+    content: "\f428"; }
+  .fa-stream:before {
+    content: "\f550"; }
+  .fa-street-view:before {
+    content: "\f21d"; }
+  .fa-strikethrough:before {
+    content: "\f0cc"; }
+  .fa-stripe:before {
+    content: "\f429"; }
+  .fa-stripe-s:before {
+    content: "\f42a"; }
+  .fa-stroopwafel:before {
+    content: "\f551"; }
+  .fa-studiovinari:before {
+    content: "\f3f8"; }
+  .fa-stumbleupon:before {
+    content: "\f1a4"; }
+  .fa-stumbleupon-circle:before {
+    content: "\f1a3"; }
+  .fa-subscript:before {
+    content: "\f12c"; }
+  .fa-subway:before {
+    content: "\f239"; }
+  .fa-suitcase:before {
+    content: "\f0f2"; }
+  .fa-suitcase-rolling:before {
+    content: "\f5c1"; }
+  .fa-sun:before {
+    content: "\f185"; }
+  .fa-superpowers:before {
+    content: "\f2dd"; }
+  .fa-superscript:before {
+    content: "\f12b"; }
+  .fa-supple:before {
+    content: "\f3f9"; }
+  .fa-surprise:before {
+    content: "\f5c2"; }
+  .fa-suse:before {
+    content: "\f7d6"; }
+  .fa-swatchbook:before {
+    content: "\f5c3"; }
+  .fa-swift:before {
+    content: "\f8e1"; }
+  .fa-swimmer:before {
+    content: "\f5c4"; }
+  .fa-swimming-pool:before {
+    content: "\f5c5"; }
+  .fa-symfony:before {
+    content: "\f83d"; }
+  .fa-synagogue:before {
+    content: "\f69b"; }
+  .fa-sync:before {
+    content: "\f021"; }
+  .fa-sync-alt:before {
+    content: "\f2f1"; }
+  .fa-syringe:before {
+    content: "\f48e"; }
+  .fa-table:before {
+    content: "\f0ce"; }
+  .fa-table-tennis:before {
+    content: "\f45d"; }
+  .fa-tablet:before {
+    content: "\f10a"; }
+  .fa-tablet-alt:before {
+    content: "\f3fa"; }
+  .fa-tablets:before {
+    content: "\f490"; }
+  .fa-tachometer-alt:before {
+    content: "\f3fd"; }
+  .fa-tag:before {
+    content: "\f02b"; }
+  .fa-tags:before {
+    content: "\f02c"; }
+  .fa-tape:before {
+    content: "\f4db"; }
+  .fa-tasks:before {
+    content: "\f0ae"; }
+  .fa-taxi:before {
+    content: "\f1ba"; }
+  .fa-teamspeak:before {
+    content: "\f4f9"; }
+  .fa-teeth:before {
+    content: "\f62e"; }
+  .fa-teeth-open:before {
+    content: "\f62f"; }
+  .fa-telegram:before {
+    content: "\f2c6"; }
+  .fa-telegram-plane:before {
+    content: "\f3fe"; }
+  .fa-temperature-high:before {
+    content: "\f769"; }
+  .fa-temperature-low:before {
+    content: "\f76b"; }
+  .fa-tencent-weibo:before {
+    content: "\f1d5"; }
+  .fa-tenge:before {
+    content: "\f7d7"; }
+  .fa-terminal:before {
+    content: "\f120"; }
+  .fa-text-height:before {
+    content: "\f034"; }
+  .fa-text-width:before {
+    content: "\f035"; }
+  .fa-th:before {
+    content: "\f00a"; }
+  .fa-th-large:before {
+    content: "\f009"; }
+  .fa-th-list:before {
+    content: "\f00b"; }
+  .fa-the-red-yeti:before {
+    content: "\f69d"; }
+  .fa-theater-masks:before {
+    content: "\f630"; }
+  .fa-themeco:before {
+    content: "\f5c6"; }
+  .fa-themeisle:before {
+    content: "\f2b2"; }
+  .fa-thermometer:before {
+    content: "\f491"; }
+  .fa-thermometer-empty:before {
+    content: "\f2cb"; }
+  .fa-thermometer-full:before {
+    content: "\f2c7"; }
+  .fa-thermometer-half:before {
+    content: "\f2c9"; }
+  .fa-thermometer-quarter:before {
+    content: "\f2ca"; }
+  .fa-thermometer-three-quarters:before {
+    content: "\f2c8"; }
+  .fa-think-peaks:before {
+    content: "\f731"; }
+  .fa-thumbs-down:before {
+    content: "\f165"; }
+  .fa-thumbs-up:before {
+    content: "\f164"; }
+  .fa-thumbtack:before {
+    content: "\f08d"; }
+  .fa-ticket-alt:before {
+    content: "\f3ff"; }
+  .fa-tiktok:before {
+    content: "\e07b"; }
+  .fa-times:before {
+    content: "\f00d"; }
+  .fa-times-circle:before {
+    content: "\f057"; }
+  .fa-tint:before {
+    content: "\f043"; }
+  .fa-tint-slash:before {
+    content: "\f5c7"; }
+  .fa-tired:before {
+    content: "\f5c8"; }
+  .fa-toggle-off:before {
+    content: "\f204"; }
+  .fa-toggle-on:before {
+    content: "\f205"; }
+  .fa-toilet:before {
+    content: "\f7d8"; }
+  .fa-toilet-paper:before {
+    content: "\f71e"; }
+  .fa-toilet-paper-slash:before {
+    content: "\e072"; }
+  .fa-toolbox:before {
+    content: "\f552"; }
+  .fa-tools:before {
+    content: "\f7d9"; }
+  .fa-tooth:before {
+    content: "\f5c9"; }
+  .fa-torah:before {
+    content: "\f6a0"; }
+  .fa-torii-gate:before {
+    content: "\f6a1"; }
+  .fa-tractor:before {
+    content: "\f722"; }
+  .fa-trade-federation:before {
+    content: "\f513"; }
+  .fa-trademark:before {
+    content: "\f25c"; }
+  .fa-traffic-light:before {
+    content: "\f637"; }
+  .fa-trailer:before {
+    content: "\e041"; }
+  .fa-train:before {
+    content: "\f238"; }
+  .fa-tram:before {
+    content: "\f7da"; }
+  .fa-transgender:before {
+    content: "\f224"; }
+  .fa-transgender-alt:before {
+    content: "\f225"; }
+  .fa-trash:before {
+    content: "\f1f8"; }
+  .fa-trash-alt:before {
+    content: "\f2ed"; }
+  .fa-trash-restore:before {
+    content: "\f829"; }
+  .fa-trash-restore-alt:before {
+    content: "\f82a"; }
+  .fa-tree:before {
+    content: "\f1bb"; }
+  .fa-trello:before {
+    content: "\f181"; }
+  .fa-tripadvisor:before {
+    content: "\f262"; }
+  .fa-trophy:before {
+    content: "\f091"; }
+  .fa-truck:before {
+    content: "\f0d1"; }
+  .fa-truck-loading:before {
+    content: "\f4de"; }
+  .fa-truck-monster:before {
+    content: "\f63b"; }
+  .fa-truck-moving:before {
+    content: "\f4df"; }
+  .fa-truck-pickup:before {
+    content: "\f63c"; }
+  .fa-tshirt:before {
+    content: "\f553"; }
+  .fa-tty:before {
+    content: "\f1e4"; }
+  .fa-tumblr:before {
+    content: "\f173"; }
+  .fa-tumblr-square:before {
+    content: "\f174"; }
+  .fa-tv:before {
+    content: "\f26c"; }
+  .fa-twitch:before {
+    content: "\f1e8"; }
+  .fa-twitter:before {
+    content: "\f099"; }
+  .fa-twitter-square:before {
+    content: "\f081"; }
+  .fa-typo3:before {
+    content: "\f42b"; }
+  .fa-uber:before {
+    content: "\f402"; }
+  .fa-ubuntu:before {
+    content: "\f7df"; }
+  .fa-uikit:before {
+    content: "\f403"; }
+  .fa-umbraco:before {
+    content: "\f8e8"; }
+  .fa-umbrella:before {
+    content: "\f0e9"; }
+  .fa-umbrella-beach:before {
+    content: "\f5ca"; }
+  .fa-uncharted:before {
+    content: "\e084"; }
+  .fa-underline:before {
+    content: "\f0cd"; }
+  .fa-undo:before {
+    content: "\f0e2"; }
+  .fa-undo-alt:before {
+    content: "\f2ea"; }
+  .fa-uniregistry:before {
+    content: "\f404"; }
+  .fa-unity:before {
+    content: "\e049"; }
+  .fa-universal-access:before {
+    content: "\f29a"; }
+  .fa-university:before {
+    content: "\f19c"; }
+  .fa-unlink:before {
+    content: "\f127"; }
+  .fa-unlock:before {
+    content: "\f09c"; }
+  .fa-unlock-alt:before {
+    content: "\f13e"; }
+  .fa-unsplash:before {
+    content: "\e07c"; }
+  .fa-untappd:before {
+    content: "\f405"; }
+  .fa-upload:before {
+    content: "\f093"; }
+  .fa-ups:before {
+    content: "\f7e0"; }
+  .fa-usb:before {
+    content: "\f287"; }
+  .fa-user:before {
+    content: "\f007"; }
+  .fa-user-alt:before {
+    content: "\f406"; }
+  .fa-user-alt-slash:before {
+    content: "\f4fa"; }
+  .fa-user-astronaut:before {
+    content: "\f4fb"; }
+  .fa-user-check:before {
+    content: "\f4fc"; }
+  .fa-user-circle:before {
+    content: "\f2bd"; }
+  .fa-user-clock:before {
+    content: "\f4fd"; }
+  .fa-user-cog:before {
+    content: "\f4fe"; }
+  .fa-user-edit:before {
+    content: "\f4ff"; }
+  .fa-user-friends:before {
+    content: "\f500"; }
+  .fa-user-graduate:before {
+    content: "\f501"; }
+  .fa-user-injured:before {
+    content: "\f728"; }
+  .fa-user-lock:before {
+    content: "\f502"; }
+  .fa-user-md:before {
+    content: "\f0f0"; }
+  .fa-user-minus:before {
+    content: "\f503"; }
+  .fa-user-ninja:before {
+    content: "\f504"; }
+  .fa-user-nurse:before {
+    content: "\f82f"; }
+  .fa-user-plus:before {
+    content: "\f234"; }
+  .fa-user-secret:before {
+    content: "\f21b"; }
+  .fa-user-shield:before {
+    content: "\f505"; }
+  .fa-user-slash:before {
+    content: "\f506"; }
+  .fa-user-tag:before {
+    content: "\f507"; }
+  .fa-user-tie:before {
+    content: "\f508"; }
+  .fa-user-times:before {
+    content: "\f235"; }
+  .fa-users:before {
+    content: "\f0c0"; }
+  .fa-users-cog:before {
+    content: "\f509"; }
+  .fa-users-slash:before {
+    content: "\e073"; }
+  .fa-usps:before {
+    content: "\f7e1"; }
+  .fa-ussunnah:before {
+    content: "\f407"; }
+  .fa-utensil-spoon:before {
+    content: "\f2e5"; }
+  .fa-utensils:before {
+    content: "\f2e7"; }
+  .fa-vaadin:before {
+    content: "\f408"; }
+  .fa-vector-square:before {
+    content: "\f5cb"; }
+  .fa-venus:before {
+    content: "\f221"; }
+  .fa-venus-double:before {
+    content: "\f226"; }
+  .fa-venus-mars:before {
+    content: "\f228"; }
+  .fa-vest:before {
+    content: "\e085"; }
+  .fa-vest-patches:before {
+    content: "\e086"; }
+  .fa-viacoin:before {
+    content: "\f237"; }
+  .fa-viadeo:before {
+    content: "\f2a9"; }
+  .fa-viadeo-square:before {
+    content: "\f2aa"; }
+  .fa-vial:before {
+    content: "\f492"; }
+  .fa-vials:before {
+    content: "\f493"; }
+  .fa-viber:before {
+    content: "\f409"; }
+  .fa-video:before {
+    content: "\f03d"; }
+  .fa-video-slash:before {
+    content: "\f4e2"; }
+  .fa-vihara:before {
+    content: "\f6a7"; }
+  .fa-vimeo:before {
+    content: "\f40a"; }
+  .fa-vimeo-square:before {
+    content: "\f194"; }
+  .fa-vimeo-v:before {
+    content: "\f27d"; }
+  .fa-vine:before {
+    content: "\f1ca"; }
+  .fa-virus:before {
+    content: "\e074"; }
+  .fa-virus-slash:before {
+    content: "\e075"; }
+  .fa-viruses:before {
+    content: "\e076"; }
+  .fa-vk:before {
+    content: "\f189"; }
+  .fa-vnv:before {
+    content: "\f40b"; }
+  .fa-voicemail:before {
+    content: "\f897"; }
+  .fa-volleyball-ball:before {
+    content: "\f45f"; }
+  .fa-volume-down:before {
+    content: "\f027"; }
+  .fa-volume-mute:before {
+    content: "\f6a9"; }
+  .fa-volume-off:before {
+    content: "\f026"; }
+  .fa-volume-up:before {
+    content: "\f028"; }
+  .fa-vote-yea:before {
+    content: "\f772"; }
+  .fa-vr-cardboard:before {
+    content: "\f729"; }
+  .fa-vuejs:before {
+    content: "\f41f"; }
+  .fa-walking:before {
+    content: "\f554"; }
+  .fa-wallet:before {
+    content: "\f555"; }
+  .fa-warehouse:before {
+    content: "\f494"; }
+  .fa-watchman-monitoring:before {
+    content: "\e087"; }
+  .fa-water:before {
+    content: "\f773"; }
+  .fa-wave-square:before {
+    content: "\f83e"; }
+  .fa-waze:before {
+    content: "\f83f"; }
+  .fa-weebly:before {
+    content: "\f5cc"; }
+  .fa-weibo:before {
+    content: "\f18a"; }
+  .fa-weight:before {
+    content: "\f496"; }
+  .fa-weight-hanging:before {
+    content: "\f5cd"; }
+  .fa-weixin:before {
+    content: "\f1d7"; }
+  .fa-whatsapp:before {
+    content: "\f232"; }
+  .fa-whatsapp-square:before {
+    content: "\f40c"; }
+  .fa-wheelchair:before {
+    content: "\f193"; }
+  .fa-whmcs:before {
+    content: "\f40d"; }
+  .fa-wifi:before {
+    content: "\f1eb"; }
+  .fa-wikipedia-w:before {
+    content: "\f266"; }
+  .fa-wind:before {
+    content: "\f72e"; }
+  .fa-window-close:before {
+    content: "\f410"; }
+  .fa-window-maximize:before {
+    content: "\f2d0"; }
+  .fa-window-minimize:before {
+    content: "\f2d1"; }
+  .fa-window-restore:before {
+    content: "\f2d2"; }
+  .fa-windows:before {
+    content: "\f17a"; }
+  .fa-wine-bottle:before {
+    content: "\f72f"; }
+  .fa-wine-glass:before {
+    content: "\f4e3"; }
+  .fa-wine-glass-alt:before {
+    content: "\f5ce"; }
+  .fa-wix:before {
+    content: "\f5cf"; }
+  .fa-wizards-of-the-coast:before {
+    content: "\f730"; }
+  .fa-wodu:before {
+    content: "\e088"; }
+  .fa-wolf-pack-battalion:before {
+    content: "\f514"; }
+  .fa-won-sign:before {
+    content: "\f159"; }
+  .fa-wordpress:before {
+    content: "\f19a"; }
+  .fa-wordpress-simple:before {
+    content: "\f411"; }
+  .fa-wpbeginner:before {
+    content: "\f297"; }
+  .fa-wpexplorer:before {
+    content: "\f2de"; }
+  .fa-wpforms:before {
+    content: "\f298"; }
+  .fa-wpressr:before {
+    content: "\f3e4"; }
+  .fa-wrench:before {
+    content: "\f0ad"; }
+  .fa-x-ray:before {
+    content: "\f497"; }
+  .fa-xbox:before {
+    content: "\f412"; }
+  .fa-xing:before {
+    content: "\f168"; }
+  .fa-xing-square:before {
+    content: "\f169"; }
+  .fa-y-combinator:before {
+    content: "\f23b"; }
+  .fa-yahoo:before {
+    content: "\f19e"; }
+  .fa-yammer:before {
+    content: "\f840"; }
+  .fa-yandex:before {
+    content: "\f413"; }
+  .fa-yandex-international:before {
+    content: "\f414"; }
+  .fa-yarn:before {
+    content: "\f7e3"; }
+  .fa-yelp:before {
+    content: "\f1e9"; }
+  .fa-yen-sign:before {
+    content: "\f157"; }
+  .fa-yin-yang:before {
+    content: "\f6ad"; }
+  .fa-yoast:before {
+    content: "\f2b1"; }
+  .fa-youtube:before {
+    content: "\f167"; }
+  .fa-youtube-square:before {
+    content: "\f431"; }
+  .fa-zhihu:before {
+    content: "\f63f"; }
+  .sr-only {
+    border: 0;
+    clip: rect(0, 0, 0, 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px; }
+  .sr-only-focusable:active, .sr-only-focusable:focus {
+    clip: auto;
+    height: auto;
+    margin: 0;
+    overflow: visible;
+    position: static;
+    width: auto; }
+  /*!
+ * Font Awesome Free 5.15.3 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+ */
+  @font-face {
+    font-family: 'Font Awesome 5 Brands';
+    font-style: normal;
+    font-weight: 400;
+    font-display: block;
+    src: url("../fonts/fontawesome-free/webfonts/fa-brands-400.eot");
+    src: url("../fonts/fontawesome-free/webfonts/fa-brands-400.eot?#iefix") format("embedded-opentype"), url("../fonts/fontawesome-free/webfonts/fa-brands-400.woff2") format("woff2"), url("../fonts/fontawesome-free/webfonts/fa-brands-400.woff") format("woff"), url("../fonts/fontawesome-free/webfonts/fa-brands-400.ttf") format("truetype"), url("../fonts/fontawesome-free/webfonts/fa-brands-400.svg#fontawesome") format("svg"); }
+  .fab {
+    font-family: 'Font Awesome 5 Brands';
+    font-weight: 400; }
+  /*!
+ * Font Awesome Free 5.15.3 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+ */
+  @font-face {
+    font-family: 'Font Awesome 5 Free';
+    font-style: normal;
+    font-weight: 900;
+    font-display: block;
+    src: url("../fonts/fontawesome-free/webfonts/fa-solid-900.eot");
+    src: url("../fonts/fontawesome-free/webfonts/fa-solid-900.eot?#iefix") format("embedded-opentype"), url("../fonts/fontawesome-free/webfonts/fa-solid-900.woff2") format("woff2"), url("../fonts/fontawesome-free/webfonts/fa-solid-900.woff") format("woff"), url("../fonts/fontawesome-free/webfonts/fa-solid-900.ttf") format("truetype"), url("../fonts/fontawesome-free/webfonts/fa-solid-900.svg#fontawesome") format("svg"); }
+  .fa,
+  .fas {
+    font-family: 'Font Awesome 5 Free';
+    font-weight: 900; }
+  html, body {
+    background-color: #222222; }
+  html {
+    scroll-behavior: smooth; }
+  html.modal-open {
+    overflow: hidden; }
+  @keyframes fadeIn {
+    from {
+      opacity: 0; }
+    to {
+      opacity: 1; } }
+  .fade-in {
+    opacity: 0;
+    animation: fadeIn ease-in 1;
+    animation-fill-mode: forwards;
+    animation-duration: 1s; }
+    .fade-in.one {
+      animation-delay: 0.7s; }
+    .fade-in.two {
+      animation-delay: 1.4s; }
+    .fade-in.three {
+      animation-delay: 1.8s; }
+  a {
+    color: #00b8d4; }
+    a:hover {
+      color: #efefef;
+      font-style: none; }
+    a:active {
+      color: #00b8d4; }
+  h1, h2, .title, .subtitle {
+    color: #efefef; }
+  p {
+    color: #ffffff; }
+  .title {
+    font-weight: 300; }
+  ul {
+    padding: 0; }
+  img {
+    border-radius: 5px;
+    border: 1px solid #efefef;
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.4); }
+  hr {
+    background-color: #efefef;
+    height: 1px; }
+  details {
+    padding: .5em .5em 0; }
+  summary {
+    margin: -.5em -.5em 0;
+    padding: .5em;
+    cursor: pointer; }
+  details[open] {
+    padding: .5em; }
+  details[open] summary {
+    margin-bottom: .5em; }
+  .container {
+    max-width: 1000px; }
+  .noborder {
+    border-radius: 0px;
+    border: none;
+    box-shadow: none; }
+  .hidden {
+    display: none; }
+  .img-responsive {
+    border-radius: 5px;
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.4); }
+  .avatar {
+    border: none; } }
+  @media screen and (prefers-color-scheme: dark) and (max-width: 768px) {
+    .avatar {
+      max-width: 50%; } }
+@media (prefers-color-scheme: dark) {
+  .thumbnail {
+    border: none; }
+  .card-thumbnail {
+    width: 100%;
+    height: 100%;
+    object-fit: cover; }
+  .bold-title {
+    font-size: 6rem;
+    line-height: 1.2;
+    margin-bottom: 0.25em; } }
+  @media screen and (prefers-color-scheme: dark) and (max-width: 768px) {
+    .bold-title {
+      font-size: 3rem;
+      text-align: center; } }
+@media (prefers-color-scheme: dark) {
+  .top-pad {
+    padding-top: 1rem; }
+  .bottom-pad {
+    padding-bottom: 1rem; }
+  .strong-post-title {
+    font-weight: 700; }
+  .post-item {
+    display: block;
+    list-style: none;
+    list-style-position: outside;
+    margin-left: 0; }
+  .post-data, .blog-share, .footer-text {
+    font-size: 1rem;
+    line-height: 2rem;
+    color: #ffffff; }
+  .social-icons {
+    padding: 0 10px; }
+    .social-icons a {
+      margin: 0 5px; }
+  .icon {
+    height: 2rem;
+    width: 2rem;
+    margin: 0 10px; }
+  .fab {
+    font-size: 1.3rem; }
+  .blog-share .icon {
+    height: 1rem;
+    width: 1rem;
+    vertical-align: baseline;
+    margin: 0 5px; }
+  .navbar {
+    background-color: #222222; }
+  .navbar-burger {
+    margin-right: auto;
+    color: #00b8d4; }
+  .navbar-burger:hover {
+    background-color: #222222; }
+  .navbar-item {
+    text-transform: uppercase;
+    font-size: 0.875rem;
+    color: #ffffff; }
+    .navbar-item:hover, .navbar-item:active {
+      background-color: #222222 !important; }
+  .owl-nav {
+    height: 50px; }
+  .owl-next, .owl-prev {
+    height: 30px; }
+    .owl-next span, .owl-prev span {
+      font-size: 3rem;
+      line-height: 30px; }
+  .footer-text {
+    font-size: 0.8em; }
+    .footer-text a {
+      color: #ffffff; }
+    .footer-text .fab {
+      font-size: 0.8em;
+      vertical-align: baseline; }
+  .tags-list {
+    width: 70%;
+    margin: 0 auto;
+    text-align: center;
+    font-size: 1.5rem; } }
+  @media screen and (prefers-color-scheme: dark) and (max-width: 768px) {
+    .tags-list {
+      width: 100%; } }
+@media (prefers-color-scheme: dark) {
+  .tag-cloud {
+    font-size: 1.5rem;
+    margin-right: 1.5rem; } }
+  @media screen and (prefers-color-scheme: dark) and (max-width: 768px) {
+    .tag-cloud {
+      font-size: 1.5rem;
+      margin-right: 1rem; } }
+@media (prefers-color-scheme: dark) {
+  .card {
+    box-shadow: none; }
+  .card-content {
+    background-color: #222222;
+    font-size: 1.5rem; }
+  .has-content-centered {
+    justify-content: center; }
+  .markdown {
+    color: #ffffff !important; }
+    .markdown p {
+      margin: 1em 0; }
+    .markdown h1 {
+      font-size: 3rem; } }
+    @media screen and (prefers-color-scheme: dark) and (max-width: 768px) {
+      .markdown h1 {
+        font-size: 2.5rem; } }
+@media (prefers-color-scheme: dark) {
+    .markdown h2 {
+      font-size: 2.5rem;
+      line-height: 1em;
+      margin-top: 1em;
+      margin-bottom: 0.5em; } }
+    @media screen and (prefers-color-scheme: dark) and (max-width: 768px) {
+      .markdown h2 {
+        font-size: 2rem; } }
+@media (prefers-color-scheme: dark) {
+    .markdown h3 {
+      font-size: 2rem; } }
+    @media screen and (prefers-color-scheme: dark) and (max-width: 768px) {
+      .markdown h3 {
+        font-size: 1.5rem; } }
+@media (prefers-color-scheme: dark) {
+    .markdown h4 {
+      font-size: 1.5rem; } }
+    @media screen and (prefers-color-scheme: dark) and (max-width: 768px) {
+      .markdown h4 {
+        font-size: 1.25rem; } }
+@media (prefers-color-scheme: dark) {
+    .markdown h5 {
+      font-size: 1.25rem; }
+    .markdown h6 {
+      font-size: 1rem; }
+    .markdown a:hover {
+      color: #efefef; }
+    .markdown ul {
+      margin-bottom: 1.25rem;
+      list-style: disc; }
+    .markdown ul ul {
+      margin-left: 0.5em;
+      margin-bottom: 0; }
+    .markdown li {
+      margin-left: 1em;
+      list-style-position: outside;
+      padding-left: 0.25em; }
+    .markdown ol {
+      margin-bottom: 1.25rem; }
+    .markdown ol ol {
+      margin-left: 0.5em;
+      list-style-type: lower-alpha;
+      margin-bottom: 0; }
+    .markdown ol ol ol {
+      list-style-type: lower-roman; }
+    .markdown em {
+      font-style: italic; }
+    .markdown strong {
+      font-weight: 700; }
+    .markdown hr {
+      position: relative;
+      margin: 1.75rem 0;
+      border: 0;
+      border-top: 1px solid #efefef; }
+    .markdown abbr {
+      font-size: 0.8rem;
+      font-weight: bold;
+      color: #666666;
+      text-transform: uppercase; }
+    .markdown abbr[title] {
+      cursor: help;
+      border-bottom: 1px dotted #808080; }
+    .markdown blockquote {
+      padding: .5rem 1rem;
+      margin: .8rem 0;
+      color: #7a7a7a;
+      border-left: .25rem solid #e5e5e5; }
+      .markdown blockquote blockquote p:last-child {
+        margin-bottom: 0; }
+    .markdown table {
+      margin: 2em 0 2em 0;
+      width: 100%;
+      border: 1px solid #e5e5e5;
+      border-collapse: collapse; }
+    .markdown td, .markdown th {
+      padding: .25rem .5rem;
+      border: 1px solid #e5e5e5;
+      text-align: center;
+      background-color: #f7f7f7; }
+    .markdown tbody tr:nth-child(odd) td,
+    .markdown tbody tr:nth-child(odd) th {
+      background-color: #dedede; }
+    .markdown tbody tr:nth-child(even) td,
+    .markdown tbody tr:nth-child(even) th {
+      background-color: #f7f7f7; }
+    .markdown code, .markdown pre {
+      border-radius: 3px; }
+    .markdown p > code, .markdown p > a > code {
+      background-color: rgba(239, 239, 239, 0.3) !important; }
+    .markdown img {
+      display: block;
+      margin: 2rem auto;
+      max-width: 100%; }
+    .markdown figure > img {
+      margin: auto; }
+    .markdown figcaption {
+      margin: 0.5rem auto;
+      max-width: 500px;
+      text-align: center; }
+    .markdown figcaption > h4 {
+      font-size: 0.8rem; }
+  .modal-card-title {
+    color: #00b8d4; }
+  .modal-card-body {
+    background-color: #222222; }
+  .markdown strong {
+    color: #ffffff; }
+  .modal-background {
+    background-color: rgba(0, 0, 0, 0.8); }
+  .modal-close {
+    background-color: #00b8d4; } }
+
+/*# sourceMappingURL=main.css.map */

--- a/resources/_gen/assets/sass/sass/style.sass_4d6f00452a35742ddbb489cb3703195e.json
+++ b/resources/_gen/assets/sass/sass/style.sass_4d6f00452a35742ddbb489cb3703195e.json
@@ -1,0 +1,1 @@
+{"Target":"css/main.css","MediaType":"text/css","Data":{}}


### PR DESCRIPTION
We first have the following error:

```
TOCSS: failed to transform "scss/main.scss"
```

After fixing, this error is gone but a similar new error occured:

```
 
hugo v0.91.2-1798BD3F+extended linux/amd6[4](https://github.com/readchina/shouchaoben/actions/runs/4022472613/jobs/6912251629#step:4:5) BuildDate=2021-12-23T1[5](https://github.com/readchina/shouchaoben/actions/runs/4022472613/jobs/6912251629#step:4:6):33:34Z VendorInfo=gohugoio
Error: Error building site: POSTCSS: failed to transform "css/main.css" (text/css). Check your PostCSS installation; install with "npm install postcss-cli". See https://gohugo.io/hugo-pipes/postcss/: this feature is not available in your current Hugo version, see https://goo.gl/YMrWcn for more information
```

This error was mentioned in an [issue](https://github.com/victoriadrake/hugo-theme-introduction/issues/227) in the repo of the theme Introduction, however, with trying the solutions mentioned there, this error still exists.



see #56 